### PR TITLE
Link was not working

### DIFF
--- a/Documentation/Setting-up-a-multi-tenant-Orchard-site.markdown
+++ b/Documentation/Setting-up-a-multi-tenant-Orchard-site.markdown
@@ -11,7 +11,7 @@ Multi-tenancy is particularly nice in a [Windows Azure environment](Deploying-Or
 because one deployment to Azure can easily support multiple websites.
 
 > **Note:** If you want to set up a multi-tenant test site on your local machine, first read
-[Testing Multi-Tenancy on a Local Machine](/Documentation/Setting-up-a-multi-tenant-Orchard-site#localhost) later in this article.
+[Testing Multi-Tenancy on a Local Machine](/Documentation/Setting-up-a-multi-tenant-Orchard-site#TestingMultiTenancyonaLocalMachine) later in this article.
 
 # Enabling Multi-Tenancy
 


### PR DESCRIPTION
The link anchor was set to #localhost instead of the real link. It was probably a placeholder while writing documentation.
