### PR TITLE
Added back in missing explanation

### DIFF
--- a/Documentation/Adding-custom-settings.markdown
+++ b/Documentation/Adding-custom-settings.markdown
@@ -52,6 +52,7 @@ Accessing your site setting is a simple one liner:
     
     var shareSettings = _services.WorkContext.CurrentSite.As<ShareBarSettingsPart>();
 
+Where _services is the `IOrchardServices` object (eg. injected in the constructor).
 
 ## Defining site scope settings (Pre-Orchard 1.8)
 


### PR DESCRIPTION
Once more mentions that `IOrchardServices` is the interface that `WorkContext` is accessed from as it had been removed in error.
