### PR TITLE
updated search to use QueryParser.Escape(query)

### DIFF
--- a/App_Code/SearchHelpers.cs
+++ b/App_Code/SearchHelpers.cs
@@ -84,9 +84,7 @@ namespace App_Code {
 
             if(q==null)
             {
-                string cooked;
-                cooked = Regex.Replace(query, @"[^\w\.@-]", " ");
-                q = qp.Parse(cooked);
+                q = qp.Parse(QueryParser.Escape(query));
             }
 
             return q;


### PR DESCRIPTION
I assume if anything changes in the future Lucene.net will update the Escape() method to handle it correctly so this method works the same and is less brittle than hardcoding our expectations into a regex.
