### PR TITLE
remove notice to say format with spaces not tabs

### DIFF
--- a/Documentation/Building-a-hello-world-module.markdown
+++ b/Documentation/Building-a-hello-world-module.markdown
@@ -43,7 +43,7 @@ You should now have a new HelloWorld folder under the Modules folder of your Orc
 
 This text file is describing your module to the system. The information contained in this file will be used for example in the features administration screen.
 
-  Note: While both spaces and tabs are supported to indent the manifest file, we recommend that you use spaces instead of tabs. As with your main coding, using spaces gives a more consistent editing experience when working in teams.
+> Note: While both spaces and tabs are supported to indent the manifest file, we recommend that you use spaces instead of tabs. As with your main coding, using spaces gives a more consistent editing experience when working in teams.
 
 # Adding the Route
 


### PR DESCRIPTION
both are valid now according to the ExtensionHarvester.cs file:

```
    private static bool IsFeatureFieldDeclaration(string line) {
        if (line.StartsWith("\t\t") ||
            line.StartsWith("\t    ") ||
            line.StartsWith("    ") ||
            line.StartsWith("    \t"))
            return true;

        return false;
    }
```
