### PR TITLE
closes #112 - use correct casing in edit link

### DIFF
--- a/_PageStart.cshtml
+++ b/_PageStart.cshtml
@@ -6,10 +6,12 @@
         Page.EditUrl = "https://github.com/OrchardCMS/OrchardDoc/blob/master/Index.markdown";
     }
     else {
-        var docName = Path.GetFileNameWithoutExtension(path);
-        Page.DocumentTitle = docName.Replace('-', ' ');
+        // https://github.com/NuGet/NuGetDocs/blob/master/Docs.Core/MarkdownEngine/MarkdownWebPage.cs
+        var caseSensitiveDocName = System.Web.Hosting.HostingEnvironment.VirtualPathProvider.GetFile(Request.Path + ".markdown").Name;
+        var docNameWithoutExtension = Path.GetFileNameWithoutExtension(caseSensitiveDocName);
+        Page.DocumentTitle = docNameWithoutExtension.Replace('-', ' ');
         Page.Title = Page.DocumentTitle + " - Orchard Documentation";
-        Page.EditUrl = "https://github.com/OrchardCMS/OrchardDoc/blob/master/Documentation/" + docName + ".markdown";
+        Page.EditUrl = "https://github.com/OrchardCMS/OrchardDoc/blob/master/Documentation/" + caseSensitiveDocName;
     }
     Page.IssuesUrl = "https://github.com/OrchardCMS/OrchardDoc/issues";
     Layout = "_SiteLayout.cshtml";


### PR DESCRIPTION
While I was doing some research I got curious as to what the `MarkdownWebPages` module was. It seems to have come originally from some code in the Nuget docs website as I can't find it anywhere else. Anyway they had a helper method to fix the casing of the whole url but we just needed the filename part so I extracted it and integrated it.

https://github.com/NuGet/NuGetDocs/blob/master/Docs.Core/MarkdownEngine/MarkdownWebPage.cs
