### PR TITLE
Adding clarification for module folder naming conventions

### DIFF
--- a/Documentation/How-Orchard-works.markdown
+++ b/Documentation/How-Orchard-works.markdown
@@ -241,6 +241,8 @@ A module typically contains event handlers, content types and their default rend
 
 Modules can be dynamically compiled from source code every time a change is made to their csproj file or to one of the files that the csproj file references. This enables a "notepad" style of development that does no require explicit compilation by the developer or even the use of an IDE such as Visual Studio.
 
+Modules must be placed in the Modules folder (Orchard.Web/Modules/MyModule) and the folder name *must* match the name of the compiled DLL produced by the project.  So, if you have a custom module project called My.Custom.Module.csproj and it compiles to My.Custom.Module.dll, then the module root folder must be named My.Custom.Module. [~/Modules/My.Custom.Module/]
+
 # Themes
 
 It is a basic design principle in Orchard that all the HTML that it produces can be replaced from themes, including markup produced by modules. Conventions define what files must go where in the theme's file hierarchy.


### PR DESCRIPTION
It is unclear that when creating a new module, the folder name that contains the module must match the file name of the compiled DLL.