### PR TITLE
Fix visual styles

### DIFF
--- a/Styles/Site.css
+++ b/Styles/Site.css
@@ -36,8 +36,8 @@ h6 {font-size: 105%;}
 
 p {line-height:20px; padding:2px 8px 1em;}
 
-ul {list-style:disc outside; line-height:22px; padding:0 0 0 24px;}
-ol {list-style:decimal outside; line-height:22px; padding:0 0 0 24px;}
+ul {list-style:disc outside; line-height:22px; padding:0 0 1em 24px;}
+ol {list-style:decimal outside; line-height:22px; padding:0 0 1em 24px;}
 
 strong {font-weight: bold;}
 em {font-style:italic;}

--- a/Styles/Site.css
+++ b/Styles/Site.css
@@ -422,12 +422,17 @@ p.editlink {font-size: 75%;}
 #PreviewDiv {
 }
 
-
 blockquote {
-	border-left: solid 8px #DDDDDD;
+	border-left: solid 8px #E66300;
+    background-color: #e6cbb6;
 	margin-left: 16px;
-	padding: 0px 0px 2px 6px;
-    margin: 10px 0 10px 0;
+	padding: .75em 0px .75em 6px;
+    margin: 1em 0;
+}
+
+blockquote p:last-child {
+    padding-bottom:  0;
+    margin-bottom: 0;
 }
 
 .search {padding:12px 0 0 12px;}

--- a/Styles/Site.css
+++ b/Styles/Site.css
@@ -356,6 +356,7 @@ html>body #ContainerDiv {height: auto;}
     margin-top: 10px;
     margin-bottom: 10px;
     max-width: 580px;
+    border: 1px solid #f9f9f9;
 }
 
 #MainFooterDiv {clear:both;}

--- a/Styles/Site.css
+++ b/Styles/Site.css
@@ -313,6 +313,9 @@ div.box {
 }
 
 
+.SiteWrapper {
+    background:url(Images/background_content.jpg) top center no-repeat #F6FAEA;
+}
 
 /* Contains the SidebarDiv and the MainDiv */
 #ContainerDiv {

--- a/Styles/Site.css
+++ b/Styles/Site.css
@@ -34,7 +34,7 @@ h4 {font-size: 125%;}
 h5 {font-size: 115%;}
 h6 {font-size: 105%;}
 
-p {line-height:20px; padding:2px 8px;}
+p {line-height:20px; padding:2px 8px 1em;}
 
 ul {list-style:disc outside; line-height:22px; padding:0 0 0 24px;}
 ol {list-style:decimal outside; line-height:22px; padding:0 0 0 24px;}

--- a/_SiteLayout.cshtml
+++ b/_SiteLayout.cshtml
@@ -31,8 +31,8 @@
                     <li><a href="http://orchardproject.net/">Home</a></li>
                     <li><a href="http://orchardproject.net/download">Download</a></li>
                     <li class="On"><a href="http://docs.orchardproject.net/">Documentation</a></li>
-                    <li><a href="http://gallery.orchardproject.net/">Gallery</a></li>
                     <li><a href="http://orchardproject.net/localization">Localization</a></li>
+                    <li><a href="http://gallery.orchardproject.net/">Gallery</a></li>
                     <li><a href="http://orchardproject.net/contribution">Contribute</a></li>
                     <li><a href="http://orchardproject.net/discussions">Discussions and Help</a></li>
                     <li><a href="http://orchardproject.net/about">About Us</a></li>

--- a/_SiteLayout.cshtml
+++ b/_SiteLayout.cshtml
@@ -39,56 +39,58 @@
                 </ul>
             </nav>
         </header>
-        <div id="ContainerDiv">
-            <div id="SidebarDiv">
-                <div id="SidebarContentDiv">
-                    <h2>Search</h2>
-                    <form action="@Href("Search.cshtml")" method="GET">
-                        <input class="txtsearchbox" type="text" name="q" value="@Request.QueryString["q"]"/><button type="submit" class="searchButton" title="Search">&raquo;</button>
-                    </form>
-                    <div>
-                        <h2>Contributors</h2>
-                        <a href="/Contributors" title="Contributors">Contributors</a>
+        <div class="SiteWrapper">
+            <div id="ContainerDiv">
+                <div id="SidebarDiv">
+                    <div id="SidebarContentDiv">
+                        <h2>Search</h2>
+                        <form action="@Href("Search.cshtml")" method="GET">
+                            <input class="txtsearchbox" type="text" name="q" value="@Request.QueryString["q"]"/><button type="submit" class="searchButton" title="Search">&raquo;</button>
+                        </form>
+                        <div>
+                            <h2>Contributors</h2>
+                            <a href="/Contributors" title="Contributors">Contributors</a>
+                        </div>
                     </div>
-                </div>
-                @if (isDoc) {
-                <h2>Table of Contents</h2>
-                <nav class="TocContainer"><ol></ol></nav>
-                <div id="SidebarFooterDiv">
-                    <ul>
-                        <li><a href="@Page.EditUrl">Edit this page</a></li>
-                        <li><a href="@Page.IssuesUrl">Submit issue</a></li>                                                
-                    </ul>
-                </div>
-                }
-            </div>
-            <article id="MainDiv">
-                <div id="MainHeaderDiv">
-                </div>
-                <div id="PageInternalHeaderDiv">
-                </div>
-                <a id="PageTop"></a>
-            	<div id="PageHeaderDiv">
-            		<h1 class="pagetitle">@Page.DocumentTitle</h1>
-    			</div>
-            	<div id="PageContentDiv">
-                    @RenderBody()
-                </div>
-            </article>
-            <footer id="MainFooterDiv">
-                <div id="siteInfo">
-                    <div id="siteInfoContent">
+                    @if (isDoc) {
+                    <h2>Table of Contents</h2>
+                    <nav class="TocContainer"><ol></ol></nav>
+                    <div id="SidebarFooterDiv">
                         <ul>
-                        <li><a href="http://orchardproject.net">Home</a></li>
-                        <li><a href="mailto:ofeedbk@microsoft.com">Contact Us</a></li>
-                        <li><a href="http://orchardproject.net/about">About Us</a></li>
-                        <li><a href="http://orchardproject.net/TermsOfUse">Terms Of Use</a></li>
-                        <li><a href="http://orchardproject.net/PrivacyStatement">Privacy Statement</a></li>
-                        <li><a href="http://appharbor.com">Hosted and Powered by AppHarbor</a></li>
+                            <li><a href="@Page.EditUrl">Edit this page</a></li>
+                            <li><a href="@Page.IssuesUrl">Submit issue</a></li>                                                
                         </ul>
                     </div>
+                    }
                 </div>
-            </footer>
+                <article id="MainDiv">
+                    <div id="MainHeaderDiv">
+                    </div>
+                    <div id="PageInternalHeaderDiv">
+                    </div>
+                    <a id="PageTop"></a>
+            	    <div id="PageHeaderDiv">
+            		    <h1 class="pagetitle">@Page.DocumentTitle</h1>
+    			    </div>
+            	    <div id="PageContentDiv">
+                        @RenderBody()
+                    </div>
+                </article>
+                <footer id="MainFooterDiv">
+                    <div id="siteInfo">
+                        <div id="siteInfoContent">
+                            <ul>
+                            <li><a href="http://orchardproject.net">Home</a></li>
+                            <li><a href="mailto:ofeedbk@microsoft.com">Contact Us</a></li>
+                            <li><a href="http://orchardproject.net/about">About Us</a></li>
+                            <li><a href="http://orchardproject.net/TermsOfUse">Terms Of Use</a></li>
+                            <li><a href="http://orchardproject.net/PrivacyStatement">Privacy Statement</a></li>
+                            <li><a href="http://appharbor.com">Hosted and Powered by AppHarbor</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </footer>
+            </div>
         </div>
         <script type="text/javascript" src="http://ajax.aspnetcdn.com/ajax/jQuery/jquery-1.7.min.js"></script>
         <script type="text/javascript" src="@Href("~/Scripts/toc.js")"></script>


### PR DESCRIPTION
I've made several readability improvements, fixed a missing background bug and brought the top nav into sync.

## Readability Improvements
### Extra Padding For `p`, `ul` and `ol` tags
Before:
![image](https://cloud.githubusercontent.com/assets/1038062/9506145/329e27c8-4c3e-11e5-9bdf-db8db9babe7c.png)
After:
![image](https://cloud.githubusercontent.com/assets/1038062/9506149/3d2bb444-4c3e-11e5-8696-b0d1a679bcfb.png)
Before:
![image](https://cloud.githubusercontent.com/assets/1038062/9506188/6db97024-4c3e-11e5-86ae-f581fb876a63.png)
After:
![image](https://cloud.githubusercontent.com/assets/1038062/9506192/74da30e6-4c3e-11e5-8eda-3f2b182c7c60.png)


### Image borders
Stop images just blending in with white background.

Before:
![image](https://cloud.githubusercontent.com/assets/1038062/9506233/c43fd406-4c3e-11e5-93bd-0218d841d357.png)
After:
![image](https://cloud.githubusercontent.com/assets/1038062/9506253/e491739a-4c3e-11e5-8694-5dfb6ca82057.png)

### Blockquotes
Blockquotes contain important information but can easily blend into the top of the page at the moment.

I've gone with a "concerned amber" colour as the markdown blockquotes don't have a concept of severity levels at the moment.

Before:
![image](https://cloud.githubusercontent.com/assets/1038062/9506261/f2eb1360-4c3e-11e5-99a6-90b88976ba83.png)
After:
![image](https://cloud.githubusercontent.com/assets/1038062/9506273/08ade07e-4c3f-11e5-8d16-32733a8ae202.png)
Multi paragraph example:
![image](https://cloud.githubusercontent.com/assets/1038062/9506284/16b3dca0-4c3f-11e5-9ae9-44c399d48805.png)


## Template Changes
### Missing Background
Left and right background collars missing.

Before:
![image](https://cloud.githubusercontent.com/assets/1038062/9506321/60d0ba9c-4c3f-11e5-9992-04623459fbbe.png)

After:
![image](https://cloud.githubusercontent.com/assets/1038062/9506326/6eceb3ec-4c3f-11e5-87b5-045e5ab8f619.png)

### Top Nav Out Of Sync
Gallery & Localization are flipped compared to main site.

Before:
![image](https://cloud.githubusercontent.com/assets/1038062/9506335/836fbf9e-4c3f-11e5-9e00-762304aff3df.png)

After:
![image](https://cloud.githubusercontent.com/assets/1038062/9506349/8c92ed76-4c3f-11e5-9b31-7df48be94e88.png)
