### PR TITLE
Short page display glitch

### DIFF
--- a/Styles/Site.css
+++ b/Styles/Site.css
@@ -323,7 +323,7 @@ div.box {
 	margin:0px auto;
 	background:url(Images/background_content.jpg) top center no-repeat #fff;
 	position: relative;
-	min-height: 100%;
+	min-height: 740px;
 	height: 100%;
 	voice-family: "\"}\"";
 	voice-family: inherit;
@@ -572,6 +572,7 @@ span.signature {
 /* Search page end */
 
 #siteInfo {
+    position:  absolute;
     bottom: 0;
     width:100%;
     display: block;


### PR DESCRIPTION
Backgrounds clashed when page was too short:

![image](https://cloud.githubusercontent.com/assets/1038062/9533825/85a59bee-4d0c-11e5-8756-40162bfec4fa.png)

This enforces a minimum height that makes the problem go away