### PR TITLE
301 test

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -1,18 +1,34 @@
 ﻿<?xml version="1.0"?>
 <configuration>
-  <appSettings>
-    <add key="bingAppId" value="Please put your Bing app id here"/>
-  </appSettings>
-  <system.web>
-    <compilation targetFramework="4.0"/>
-    <customErrors mode="RemoteOnly"/>
-  </system.web>
-  <system.webServer>
-    <defaultDocument>
-      <files>
-        <add value="Index.markdown"/>
-      </files>
-    </defaultDocument>
-    <modules runAllManagedModulesForAllRequests="true"/>
-  </system.webServer>
+   <appSettings>
+      <add key="bingAppId" value="Please put your Bing app id here"/>
+   </appSettings>
+   <system.web>
+      <compilation targetFramework="4.0"/>
+      <customErrors mode="RemoteOnly"/>
+   </system.web>
+   <system.webServer>
+      <defaultDocument>
+         <files>
+            <add value="Index.markdown"/>
+         </files>
+      </defaultDocument>
+      <modules runAllManagedModulesForAllRequests="true"/>
+      <rewrite>
+         <rewriteMaps>
+            <rewriteMap name="StaticRewrites" defaultValue="">
+               <add key="/documentation/" value="/" />
+            </rewriteMap>
+         </rewriteMaps>
+         <rules>
+            <rule name="StaticRewrites RewriteMap Rule">
+               <match url=".*" />
+               <conditions>
+                  <add input="{StaticRewrites:{REQUEST_URI}}" pattern="(.+)" />
+               </conditions>
+               <action type="Redirect" url="{C:1}" />
+            </rule>
+         </rules>
+      </rewrite>
+   </system.webServer>
 </configuration>


### PR DESCRIPTION
added a url rewrite section to the web.config to redirect `/Documentation/` to the homepage.

Stops users potentially seeing an 404 error page and also confirms that 301 redirects are enabled on the server for future use when reorganising.