### PR TITLE
clean up the fragment regex

### DIFF
--- a/Scripts/toc.js
+++ b/Scripts/toc.js
@@ -8,7 +8,7 @@ jQuery(function($) {
     $("#MainDiv :header")
         .each(function() {
             var h = $(this),
-                name = h.text().replace(/[\s,-;\.]/g, "");
+                name = h.text().replace(/[^A-Za-z0-9\-]/g, "");
             h.before($("<a/>", {name: name}));
             toc.append(
                 $("<li></li>").append(


### PR DESCRIPTION
Fixes #222 

Cleaned up the #fragment generation to strip everything except letters and numbers.

Previously it was generating urls with `?` and other characters like `®`

Potentially may break some existing internal links within the documentation but I have done a regex search on the existing docs for fragments containing `?` or `'` but there weren't any.

If it does break a link then it will still direct them to the page it just won't scroll it down to the #fragment.