### PR TITLE
fix table bug

### DIFF
--- a/App_Code/MarkdownExtensions.cs
+++ b/App_Code/MarkdownExtensions.cs
@@ -46,6 +46,7 @@ namespace App_Code {
                     writer.WriteLine("    </tr>");
                 }
                 writer.WriteLine("</tbody></table>");
+                writer.WriteLine("");
                 return writer.ToString();
             }
             , RegexOptions.Multiline);


### PR DESCRIPTION
Fixes #220 

Just added an extra blank line after the table because the regex was consuming it and confusing the underlying markdown parser