### PR TITLE
Update index.markdown

### DIFF
--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -1,4 +1,4 @@
-> **Note:** This documentation site, like all of Orchard, is a [community effort](/Contributors). If you would like to contribute, please see [Documentation Style Guidelines](Documentation/Documentation-style-guidelines)
+> **Note:** This documentation site, like all of Orchard, is a [community effort](/Contributors). If you would like to contribute, please see [Documentation Style Guidelines](Documentation/Documentation-Style-Guidelines)
 and [Suggestions for New Topics](Documentation/Suggestions-for-New-Topics).
 
 ## Getting Started ##


### PR DESCRIPTION
Error in letter register lead to ERR_TOO_MANY_REDIRECTS in Chromium under Gentoo Linux.
The same in the FireFox.

The docs.orchardproject.net page isn’t working
docs.orchardproject.net redirected you too many times.
Try clearing your cookies.
ERR_TOO_MANY_REDIRECTS