### PR TITLE
Capitalize a file name.

### DIFF
--- a/docs/Documentation/Writing-a-content-part.markdown
+++ b/docs/Documentation/Writing-a-content-part.markdown
@@ -226,7 +226,7 @@ Views/Parts/Map.cshtml :
          &sensor=false" />
 
 
-Both of these templates will be rendered as parts of a larger, composite page. Because the system needs to know the order and location where they will render within the composed page, we need to add a placement.info file into the root of the module's directory:
+Both of these templates will be rendered as parts of a larger, composite page. Because the system needs to know the order and location where they will render within the composed page, we need to add a Placement.info file into the root of the module's directory:
 
     
     <Placement>


### PR DESCRIPTION
Super small change, but all Placement.info files ive seen have used capital letters. When I ran through these instructions and couldnt fine my error, I thought maybe this had messed things up (it hadn't). Making the change regardless in case this confuses someone else.