### PR TITLE
Editing while reading

### DIFF
--- a/docs/Documentation/Accessing-and-rendering-shapes.markdown
+++ b/docs/Documentation/Accessing-and-rendering-shapes.markdown
@@ -1,6 +1,6 @@
 A _shape_ is a dynamic data model.
 The purpose of a shape is to replace the static view model of ASP.NET MVC by using a model
-that can be updated at run time&#151;that is, by using a dynamic shape.
+that can be updated at runtime -- that is, by using a dynamic shape.
 You can think of shapes as the blobs of data that get handed to templates for rendering.
 
 This article introduces the concept of shapes and explains how to work with them.
@@ -47,7 +47,7 @@ the `ActionResult` object returned by action methods in ASP.NET MVC.
 The `ContentShape` method helps you create the shape and return it in a `ContentShapeResult` object.
 
 Although the `ContentShape` method is overloaded, the most typical use is to pass it two
-parameters&#151;the shape type and a dynamic function expression that defines the shape.
+parameters -- the shape type and a dynamic function expression that defines the shape.
 The shape type names the shape and binds the shape to the template that will be used to render it.
 The naming conventions for shape types are discussed later in
 [Naming Shapes and Templates](Accessing-and-rendering-shapes#NamingShapesandTemplates).
@@ -119,7 +119,7 @@ This is a special shape that has a `TemplateName` property and a `Model` propert
 The `TemplateName` property takes a partial path to the template.
 In this case, `"Parts/Map"` causes Orchard to look for a template in your module at the following path: 
 
-_Views/EditorTemplates/Parts/Map.cshtml_
+`Views/EditorTemplates/Parts/Map.cshtml`
 
 The `Model` property takes the name of the part's model file, but without the file-name extension.
 
@@ -129,66 +129,66 @@ As noted, the name given to a shape type binds the shape to the template that wi
 For example, suppose you create a part named `Map` that displays a map for the specified longitude and latitude.
 The name of the shape type might be `Parts_Map`. By convention, all part shapes begin with `Parts_` followed by the name of the part (in this case `Map`). Given this name (`Parts_Map`), Orchard looks for a template in your module at the following path: 
 
-_views/parts/Map.cshtml_
+`views/parts/Map.cshtml`
 
 The following table summarizes the conventions that are used to name shape types and templates.
 
-Applied To             | Shape Naming Convention                                           | Shape Type Example                                   | Template Example
----------------------- | ----------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------
-Content shapes         | Content\_\_\[ContentType\]                                        | Content\_\_BlogPost                                  | Content-BlogPost
-Content shapes         | Content\_\_\[Id\]                                                 | Content\_\_42                                        | Content-42
-Content shapes         | Content\_\_\[DisplayType\]                                        | Content\_\_Summary                                   | Content.Summary
-Content shapes         | Content\_\[DisplayType\]\_\_\[ContentType\]                       | Content\_Summary\_\_BlogPost                         | Content-BlogPost.Summary
-Content shapes         | Content\_\[DisplayType\]\_\_\[Id\]                                | Content\_Summary\_\_42                               | Content-42.Summary
-Content.Edit shapes    | Content\_Edit\_\_\[DisplayType\]                                  | Content\_Edit\_\_Page                                | Content-Page.Edit
-Content Part templates | \[ShapeType\]\_\_\[Id\]                                           | Parts\_Common\_Metadata\_\_42                        | Parts/Common.Metadata-42
-Content Part templates | \[ShapeType\]\_\_\[ContentType\]                                  | Parts\_Common\_Metadata\_\_BlogPost                  | Parts/Common.Metadata-BlogPost
-Field templates        | \[ShapeType\]\_\_\[FieldName\]                                    | Fields\_Common\_Text\_\_Teaser                       | Fields/Common.Text-Teaser
-Field templates        | \[ShapeType\]\_\_\[PartName\]                                     | Fields\_Common\_Text\_\_TeaserPart                   | Fileds/Common.Text-TeaserPart
-Field templates        | \[ShapeType\]\_\_\[ContentType\]\_\_\[PartName\]                  | Fields\_Common\_Text\_\_Blog\_\_TeaserPart           | Fields/Common.Text-Blog-TeaserPart
-Field templates        | \[ShapeType\]\_\_\[PartName\]\_\_\[FieldName\]                    | Fields\_Common\_Text\_\_TeaserPart\_\_Teaser         | Fields/Common.Text-TeaserPart-Teaser
-Field templates        | \[ShapeType\]\_\_\[ContentType\]\_\_\[FieldName\]                 | Fields\_Common\_Text\_\_Blog\_\_Teaser               | Fields/Common.Text-Blog-Teaser
-Field templates        | \[ShapeType\]\_\_\[ContentType\]\_\_\[PartName\]\_\_\[FieldName\] | Fields\_Common\_Text\_\_Blog\_\_TeaserPart\_\_Teaser | Fields/Common.Text-Blog-TeaserPart-Teaser
-LocalMenu              | LocalMenu\_\_\[MenuName\]                                         | LocalMenu\_\_main                                    | LocalMenu-main
-LocalMenuItem          | LocalMenuItem\_\_\[MenuName\]                                     | LocalMenuItem\_\_main                                | LocalMenuItem-main
-Menu                   | Menu\_\_\[MenuName\]                                              | Menu\_\_main                                         | Menu-main
-MenuItem               | MenuItem\_\_\[MenuName\]                                          | MenuItem\_\_main                                     | MenuItem-main
-Resource               | Resource\_\_\[FileName\]                                          | Resource\_\_flower\.gif                              | Resource-flower.gif
-Style                  | Style\_\_\[FileName\]                                             | Style\_\_site\.css                                   | Style-site.css
-Widget                 | Widget\_\_\[ContentType\]                                         | Widget\_\_HtmlWidget                                 | Widget-HtmlWidget
-Widget                 | Widget\_\_\[ZoneName\]                                            | Widget\_\_AsideSecond                                | Widget-AsideSecond
-Zone                   | Zone\_\_\[ZoneName\]                                              | Zone\_\_AsideSecond                                  | Zone-AsideSecond
+Applied To             | Shape Naming Convention                                | Shape Type Example                             | Template Example
+---------------------- | ------------------------------------------------------ | -----------------------------------------------| --------------------------------------------
+Content shapes         | `Content__[ContentType]`                               | `Content__BlogPost`                            | `Content-BlogPost`
+Content shapes         | `Content__[Id]`                                        | `Content__42`                                  | `Content-42`
+Content shapes         | `Content__[DisplayType]`                               | `Content__Summary`                             | `Content.Summary`
+Content shapes         | `Content_[DisplayType]__[ContentType]`                 | `Content_Summary__BlogPost`                    | `Content-BlogPost.Summary`
+Content shapes         | `Content_[DisplayType]__[Id]`                          | `Content_Summary__42`                          | `Content-42.Summary`
+Content.Edit shapes    | `Content_Edit__[DisplayType]`                          | `Content_Edit__Page`                           | `Content-Page.Edit`
+Content Part templates | `[ShapeType]__[Id]`                                    | `Parts_Common_Metadata__42`                    | `Parts/Common.Metadata-42`
+Content Part templates | `[ShapeType]__[ContentType]`                           | `Parts_Common_Metadata__BlogPost`              | `Parts/Common.Metadata-BlogPost`
+Field templates        | `[ShapeType]__[FieldName]`                             | `Fields_Common_Text__Teaser`                   | `Fields/Common.Text-Teaser`
+Field templates        | `[ShapeType]__[PartName]`                              | `Fields_Common_Text__TeaserPart`               | `Fileds/Common.Text-TeaserPart`
+Field templates        | `[ShapeType]__[ContentType]__[PartName]`               | `Fields_Common_Text__Blog__TeaserPart`         | `Fields/Common.Text-Blog-TeaserPart`
+Field templates        | `[ShapeType]__[PartName]__[FieldName]`                 | `Fields_Common_Text__TeaserPart__Teaser`       | `Fields/Common.Text-TeaserPart-Teaser`
+Field templates        | `[ShapeType]__[ContentType]__[FieldName]`              | `Fields_Common_Text__Blog__Teaser`             | `Fields/Common.Text-Blog-Teaser`
+Field templates        | `[ShapeType]__[ContentType]__[PartName]__[FieldName]`  | `Fields_Common_Text__Blog__TeaserPart__Teaser` | `Fields/Common.Text-Blog-TeaserPart-Teaser`
+LocalMenu              | `LocalMenu__[MenuName]`                                | `LocalMenu__main`                              | `LocalMenu-main`
+LocalMenuItem          | `LocalMenuItem__[MenuName]`                            | `LocalMenuItem__main`                          | `LocalMenuItem-main`
+Menu                   | `Menu__[MenuName]`                                     | `Menu__main`                                   | `Menu-main`
+MenuItem               | `MenuItem__[MenuName]`                                 | `MenuItem__main`                               | `MenuItem-main`
+Resource               | `Resource__[FileName]`                                 | `Resource__flower.gif`                         | `Resource-flower.gif`
+Style                  | `Style__[FileName]`                                    | `Style__site.css`                              | `Style-site.css`
+Widget                 | `Widget__[ContentType]`                                | `Widget__HtmlWidget`                           | `Widget-HtmlWidget`
+Widget                 | `Widget__[ZoneName]`                                   | `Widget__AsideSecond`                          | `Widget-AsideSecond`
+Zone                   | `Zone__[ZoneName]`                                     | `Zone__AsideSecond`                            | `Zone-AsideSecond`
 
 You should put your templates in the project according to the following rules:
 
-* Content item shape templates are in the _views/items_ folder.
-* `Parts_` shape templates are in the _views/parts_ folder.
-* `Fields_` shape templates are in the _views/fields_ folder.
-* The `EditorTemplate` shape templates are in the _views/EditorTemplates/_`template` name folder.  
-For example, an `EditorTemplate` with a template name of _Parts/Routable.RoutePart_ has its template
-at _views/EditorTemplates/Parts/Routable.RoutePart.cshtml_.
-* All other shape templates are in the _views_ folder.
+* Content item shape templates are in the `Views/Items` folder.
+* `Parts_` shape templates are in the `Views/Parts` folder.
+* `Fields_` shape templates are in the `Views/Fields` folder.
+* The `EditorTemplate` shape templates are in the `Views/EditorTemplates/<templatename>` folder.  
+For example, an `EditorTemplate` with a template name of `Parts/Routable.RoutePart` has its template
+at `Views/EditorTemplates/Parts/Routable.RoutePart.cshtml`.
+* All other shape templates are in the `Views` folder.
 
-> **Note**`  `The template extension can be any extension supported by an active view engine, such as _.cshtml_, _.vbhtml_, or _.ascx_.
+> **Note**: The template extension can be any extension supported by an active view engine, such as `.cshtml`, `.vbhtml`, or `.ascx`.
 
 ## From Template File Name to Shape Name
 
 More generally, the rules to map from a template file name to the corresponding shape name are the following:
 
-* Dot (.) and backslash (\\) change to underscore (\_).
-Note that this does not mean that an _example.cshtml_ file in a _myviews_ subdirectory of _Views_
-is equivalent to a _myviews_example.chtml_ file in _Views_.
+* Dot (`.`) and backslash (`\ `) change to underscore (`_`).
+Note that this does not mean that an `example.cshtml` file in a `myviews` subdirectory of `Views`
+is equivalent to a `myviews`example.chtml` file in `Views_.
 The shape templates must still be in the expected directory (see above).
-* Hyphen (-) changes to a double underscore (\_\_).
+* Hyphen (`-`) changes to a double underscore (`__`).
 
-For example, _Views/Hello.World.cshtml_ will be used to render a shape named `Hello_World`,
-and _Views/Hello.World-85.cshtml_ will be used to render a shape named `Hello_World__85`.
+For example, `Views/Hello.World.cshtml` will be used to render a shape named `Hello_World`,
+and `Views/Hello.World-85.cshtml` will be used to render a shape named `Hello_World__85`.
 
 ## Alternate Shape Rendering
 
 As noted, an HTML widget in the `AsideSecond` zone (for example) could be rendered
-by a _widget.cshtml_ template, by a _widget-htmlwidget.cshtml_ template,
-or by a _widget-asidesecond.cshtml_ if they exist in the current theme.
+by a `widget.cshtml` template, by a `widget-htmlwidget.cshtml` template,
+or by a `widget-asidesecond.cshtml` if they exist in the current theme.
 When various possibilities exist to render the same content,
 these are referred to as _alternates_ of the shape,
 and they enable rich template overriding scenarios.
@@ -197,15 +197,15 @@ Alternates form a group that corresponds to the same shape if they differ only b
 For example, `Hello_World`, `Hello_World__85`, and `Hello_World__DarkBlue` are an alternate group
 for a `Hello_World` shape. `Hello_World_Summary`, conversely, does not belong to that group
 and would correspond to a `Hello_World_Shape` shape, not to a `Hello_World` shape.
-(Notice the difference between "\_\_" and "\_".)
+(Notice the difference between "`__`" and "`_`".)
 
 ## Which Alternate Will Be Rendered?
 
 Even if it has alternates, a shape is always created with the base name, such as `Hello_World`.
 Alternates give additional template name options to the theme developer beyond the default
-(such as _hello.world.cshtml_).
+(such as `hello.world.cshtml`).
 The system will choose the most specialized template available among the alternates,
-so _hello.world-orange.cshtml_ will be preferred to _hello.world.cshtml_ if it exists.
+so `hello.world-orange.cshtml` will be preferred to `hello.world.cshtml` if it exists.
 
 ## Built-In Content Item Alternates
 
@@ -272,18 +272,18 @@ The `@Html.ValidationMessageFor` expressions create messages that are displayed 
 ## Wrappers
 
 Wrappers let you customize the rendering of a shape by adding markup around the shape.
-For example, _Document.cshtml_ is a wrapper for the `Layout` shape, because it specifies
+For example, `Document.cshtml` is a wrapper for the `Layout` shape, because it specifies
 the markup code that  surrounds the `Layout` shape.
 For more information about the relationship between `Document` and `Layout`,
 see [Template File Syntax Guide](Template-file-syntax-guide).
 
-Typically, you add a wrapper file to the _Views_ folder of  your theme.
-For example, to add a wrapper for `Widget`, you add a _Widget.Wrapper.cshtml_ file to
-the _Views_ folder of your theme.
+Typically, you add a wrapper file to the `Views` folder of  your theme.
+For example, to add a wrapper for `Widget`, you add a `Widget.Wrapper.cshtml` file to
+the `Views` folder of your theme.
 If you enable the **Shape Tracing** feature, you'll see the available wrapper names for a shape.
-You can also specify a wrapper in the _placement.info_ file.
+You can also specify a wrapper in the `Placement.info` file.
 For more information about how to specify  a wrapper,
-see [Understanding the placement.info File](Understanding-placement-info).
+see [Understanding the Placement.info File](Understanding-placement-info).
 
 # Creating a Shape Method
 

--- a/docs/Documentation/Alternates.markdown
+++ b/docs/Documentation/Alternates.markdown
@@ -16,7 +16,7 @@ without requiring you to modify any code.
 
 ## Naming Convention for Alternates
 
-Alternate shapes are named using the name of the base shape followed by a double underscore \(\_\_\)
+Alternate shapes are named using the name of the base shape followed by a double underscore (`__`)
 and an ending that is specific to the alternate shape.
 For example, a `Parts_Tags_ShowTags` shape can have alternates with names such as
 `Parts_Tags_ShowTags__BlogPost` and `Parts_Tags_ShowTags__Page`.
@@ -29,35 +29,35 @@ see [Accessing and Rendering Shapes](Accessing-and-rendering-shapes).)
 To create a template file that maps to the corresponding shape name,
 you must name the template according to the  following naming convention:
 
-* Convert an underscore (_) in the shape name to either a dot (.) or backslash (\\) in the template name.
-A backslash indicates that the template resides in a subfolder.
-* Convert a double underscore \(\_\_\) in the shape name to a hyphen (-).
-* For any Display type value in the shape name, place the type name after a dot (.)
-at the end of the template name, such as Content-BlogPost.Summary.
+* Convert an underscore (`_`) in the shape name to either a dot (`.`) or backslash (`\ `) in the template name.
+  A backslash indicates that the template resides in a subfolder.
+* Convert a double underscore (`__`) in the shape name to a hyphen (`-`).
+* For any Display type value in the shape name, place the type name after a dot (`.`)
+  at the end of the template name, such as `Content-BlogPost.Summary`.
 
-All templates for alternates must reside in the _Views_ folder.
-The _Views_ folder can be located either in the theme or in the module.
-The following table shows which subfolders of _Views_ to use for different types of templates.
+All templates for alternates must reside in the `Views` folder.
+The `Views` folder can be located either in the theme or in the module.
+The following table shows which subfolders of `Views` to use for different types of templates.
 
 Shape type     | Template Folder
 -------------- | ----------------
-Content item   | _Views\\Items_
-Parts          | _Views\\Parts_
-Fields         | _Views\\Fields_
-EditorTemplate | _Views\\EditorTemplates\\[template type folder\]_ (For example, an **EditorTemplate** for a part is located at _Views\EditorTemplates\Parts_.)
-All other      | _Views_
+Content item   | `Views\Items`
+Parts          | `Views\Parts`
+Fields         | `Views\Fields`
+EditorTemplate | `Views\EditorTemplates\[template type folder]` (For example, an `EditorTemplate` for a part is located at `Views\EditorTemplates\Parts`.)
+All other      | `Views`
 
-For example, to create an alternate template for the **Tags** part, you can add a template
-to the _MyTheme\Views\Parts_ folder.
-However, because the underscore can be converted to either a dot (.) or backslash (\),
-you can also create a template in the _Views_ folder and add _Parts._ to the beginning of the name.
-A template at either _Views\Parts\Tags.ShowTags-BlogPost.cshtml_ or
-_Views\Parts.Tags.ShowTags-BlogPost.cshtml_ will map to a shape named `Parts_Tags_ShowTags__BlogPost`.
+For example, to create an alternate template for the `Tags` part, you can add a template
+to the `MyTheme\Views\Parts` folder.
+However, because the underscore can be converted to either a dot (`.`) or backslash (`\ `),
+you can also create a template in the `Views` folder and add `Parts.` to the beginning of the name.
+A template at either `Views\Parts\Tags.ShowTags-BlogPost.cshtml` or
+`Views\Parts.Tags.ShowTags-BlogPost.cshtml` will map to a shape named `Parts_Tags_ShowTags__BlogPost`.
 
 If the Orchard framework cannot locate an alternate template that has the expected name,
 the default template will be used for those shapes.
 For example, if you do not create an alternate for showing tags, the default template for tags
-(located at _Views\Parts\Tags.ShowTags.cshtml_) is used.
+(located at `Views\Parts\Tags.ShowTags.cshtml`) is used.
 
 The Orchard framework automatically creates many alternates that you can use in your application.
 However, you can create templates for these alternate shapes.
@@ -65,54 +65,54 @@ The patterns for creating alternates are shown below, with examples of matching 
 
 For **Content** shapes:
 
-* _Content\_\_\[DisplayType\]_. (Example template: `Content.Summary`)
-* _Content\_\_\[ContentType\]_. (Example template: `Content-BlogPost`)
-* _Content\_\_\[Id\]_. (Example template: `Content-42`)
-* _Content_\[DisplayType\]\_\_\[ContentType\]_. (Example template: `Content-BlogPost.Summary`)
-* _Content_\[DisplayType\]\_\_\[Id\]_. (Example template: `Content-42.Summary`)
+* `Content__[DisplayType]`. (Example template: `Content.Summary`)
+* `Content__[ContentType]`. (Example template: `Content-BlogPost`)
+* `Content__[Id]`. (Example template: `Content-42`)
+* `Content_[DisplayType]__[ContentType]`. (Example template: `Content-BlogPost.Summary`)
+* `Content_[DisplayType]__[Id]`. (Example template: `Content-42.Summary`)
 
 For **Zone** shapes:
 
-* _Zone\_\_\[ZoneName\]_. (Example template: `Zone-SideBar`)
+* `Zone__[ZoneName]`. (Example template: `Zone-SideBar`)
 
 For **Navigation** shapes (the new menu system since version 1.5):
 
-* _MenuItemLink\_\_\[MenuName\]_. (Example template: `MenuItemLink-main-menu`)
-* _MenuItemLink\_\_\[ContentType\]_. (Examples template: `MenuItemLink-ContentMenuItem`, `MenuItemLink-HtmlMenuItem`, `MenuItemLink-Blog`)
+* `MenuItemLink__[MenuName]`. (Example template: `MenuItemLink-main-menu`)
+* `MenuItemLink__[ContentType]`. (Examples template: `MenuItemLink-ContentMenuItem`, `MenuItemLink-HtmlMenuItem`, `MenuItemLink-Blog`)
 
 For menu and menu item shapes:
 
-* _Menu\_\_\[MenuName\]_. (Example template: `Menu-main`)
-* _MenuItem\_\_\[MenuName\]_. (Example template: `MenuItem-main`)
+* `Menu__[MenuName]`. (Example template: `Menu-main`)
+* `MenuItem__[MenuName]`. (Example template: `MenuItem-main`)
 
 For local menu and local menu item shapes:
 
-* _LocalMenu\_\_\[MenuName\]_. (Example template: `LocalMenu-main`)
-* _LocalMenuItem\_\_\[MenuName\]_. (Example template: `LocalMenuItem-main`)
+* `LocalMenu__[MenuName]`. (Example template: `LocalMenu-main`)
+* `LocalMenuItem__[MenuName]`. (Example template: `LocalMenuItem-main`)
 
 For styles and resources:
 
-* _Style\_\_\[FileName\]_
-* _Resource\_\_\[FileName\]_
+* `Style__[FileName]`
+* `Resource__[FileName]`
 
 For widget shapes:
 
-* _Widget\_\_\[ZoneName\]_. (Example template: `Widget-SideBar`)
-* _Widget\_\_\[ContentType\]_. (Example template: `Widget-BlogArchive`)
+* `Widget__[ZoneName]`. (Example template: `Widget-SideBar`)
+* `Widget__[ContentType]`. (Example template: `Widget-BlogArchive`)
 
 For fields:
 
-* _\[ShapeType\_\_FieldName\]_. (Example template: `Fields\Common.Text-Teaser`)
-* _\[ShapeType\_\_PartName\]_. (Example template: `Fields\Common.Text-TeaserPart`)
-* _\[ShapeType\]\_\_\[ContentType\]\_\_\[PartName\]_. (Example template: `Fields\Common.Text-Blog-TeaserPart`)
-* _\[ShapeType\]\_\_\[PartName\]\_\_\[FieldName\]_. (Example template: `Fields\Common.Text-TeaserPart-Teaser`)
-* _\[ShapeType\]\_\_\[ContentType\]\_\_\[FieldName\]_. (Example template: `Fields\Common.Text-Blog-Teaser`)
-* _\[ShapeType\]\_\_\[ContentType\]\_\_\[PartName\]\_\_\[FieldName\]_. (Example template: `Fields\Common.Text-Blog-TeaserPart-Teaser`)
+* `[ShapeType__FieldName]`. (Example template: `Fields\Common.Text-Teaser`)
+* `[ShapeType__PartName]`. (Example template: `Fields\Common.Text-TeaserPart`)
+* `[ShapeType]__[ContentType]__[PartName]`. (Example template: `Fields\Common.Text-Blog-TeaserPart`)
+* `[ShapeType]__[PartName]__[FieldName]`. (Example template: `Fields\Common.Text-TeaserPart-Teaser`)
+* `[ShapeType]__[ContentType]__[FieldName]`. (Example template: `Fields\Common.Text-Blog-Teaser`)
+* `[ShapeType]__[ContentType]__[PartName]__[FieldName]`. (Example template: `Fields\Common.Text-Blog-TeaserPart-Teaser`)
 
 For content parts:
 
-* _\[ShapeType\]\_\_\[Id\]_. (Example template: `Parts\Common.Metadata-42`)
-* _\[ShapeType\]\_\_\[ContentType\]_. (Example template: `Parts\Common.Metadata-BlogPost`)
+* `[ShapeType]__[Id]`. (Example template: `Parts\Common.Metadata-42`)
+* `[ShapeType]__[ContentType]`. (Example template: `Parts\Common.Metadata-BlogPost`)
 
 You can use the **Shape Tracing** module to generate alternate templates through the **Shape Tracing** user interface. For more information, see [Customizing Orchard using Designer Helper Tools](Customizing-Orchard-using-Designer-Helper-Tools).
 
@@ -124,7 +124,7 @@ You must enable the **URL Alternates** and **Widget Alternates** modules in orde
 When enabled, alternate shapes are created based on the URL or the zone.
 These URL alternates are combined with the alternate patterns defined above.
 
-For example, the URL _/my-blog/post-1_ has alternates available for a `MenuItem` object
+For example, the URL `/my-blog/post-1` has alternates available for a `MenuItem` object
 with the following template names:
 
 `MenuItem-main`  
@@ -138,10 +138,10 @@ For the homepage, the following alternate is available:
 Using this module, you can add URL-specific alternates to the **Layout** shape, such as the following: 
 `Layout-url-homepage`. This adds a specific layout for your About page of your site.
 
-Creating a new layout file in your Themes/ThemeName/Views named `Layout-url-About.cshtml`
-would be picked up and used when viewing the /About page in your site.
+Creating a new layout file in your `Themes/ThemeName/Views` named `Layout-url-About.cshtml`
+would be picked up and used when viewing the `/About` page in your site.
 
-> **Note:** if the changes are only small, perhaps using alternate url naming to the zone would be more appropriate.
+> **Note:** if the changes are only small, perhaps using alternate URL naming to the zone would be more appropriate.
 
 You can enable URL Alternates by downloading the Designer Tools module from the Orchard Team
 in the Orchard Modules Gallery:
@@ -155,15 +155,15 @@ module) is a great way to discover what alternates are available for any shape t
 
 Here are some examples of widget alternate template names:
 
-`Parts.Common.Body-HtmlWidget-TripelSecond`  
-`Parts.Common.Body-TripelSecond`
+- `Parts.Common.Body-HtmlWidget-TripelSecond`  
+- `Parts.Common.Body-TripelSecond`
 
 ## Explicitly Designating an Alternate Template
 
 In addition to using the automatically generated alternates, you can manually specify an alternate.
-In a _placement.info_ file, you can specify which alternates are available for a content type.
+In a `Placement.info` file, you can specify which alternates are available for a content type.
 For example, to specify a different template (identified as `Parts_Tags_ShowTags_BlogPost`)
-for rendering the tags for blog posts, you can revise the _placement.info_ file for the
+for rendering the tags for blog posts, you can revise the `Placement.info` file for the
 **Orchard.Tags** module to include an element that matches `BlogPost` types.
 The following example shows the revised file.
     
@@ -185,26 +185,26 @@ Only the first matched element is used to render the item.
 In the example, placing the element for `BlogPost` below `Detail` and `Summary` means
 that `ShowTags_BlogPost` will not be used, even for `BlogPost` items,
 because the earlier elements match the item.
-For more information about the _placement.info_ file, see
+For more information about the `Placement.info` file, see
 [Understanding placement.info](Understanding-placement-info).
 
 ## Alternates for MVC views
 Some modules in Orchard use regular MVC views to render the results of an action that was invoked on a custom controller. To customize the look of the pages produced by custom MVC controllers in Orchard, you need to add a version of the view file in your theme's `Views` folder.
 
-For example, if you want to customize the search results page of the Orchard Search module (Orchard.Search) you need to add a file in the following folder of your theme:
+For example, if you want to customize the search results page of the Orchard Search module (`Orchard.Search`) you need to add a file in the following folder of your theme:
 
     /Themes/{Your theme}/Views/Orchard.Search/Search/Index.cshtml
 
-This file will override the default view used by the Orchard.Search module. 
-The ViewEngine used by Orchard will look for the following pattern when resolving MVC views.
+This file will override the default view used by the `Orchard.Search` module. 
+The `ViewEngine` used by Orchard will look for the following pattern when resolving MVC views.
 
-- ~/Themes/{Active theme}/Views/{Area}/{Controller}/{View}.cshtml
-- ~/Themes/{Active theme}/Views/{Controller}/{View}.cshtml
-- ~/Themes/{Active theme}/{Partial}.cshtml
-- ~/Themes/{Active theme}/DisplayTemplates/{TemplateName}.cshtml
-- ~/Themes/{Active theme}/EditorTemplates/{TemplateName}.cshtml
+- `~/Themes/[Active theme]/Views/[Area]/[Controller]/[View].cshtml`
+- `~/Themes/[Active theme]/Views/[Controller]/[View].cshtml`
+- `~/Themes/[Active theme]/[Partial].cshtml`
+- `~/Themes/[Active theme]/DisplayTemplates/[TemplateName].cshtml`
+- `~/Themes/[Active theme]/EditorTemplates/[TemplateName].cshtml`
 
-Please be aware, any other convention that is normally supported in MVC is not supported within a theme. Unless specified in the list above. 
+Please be aware, any other convention that is normally supported in MVC is not supported within a theme, unless specified in the list above. 
 
 ## Adding Alternates Through Code
 

--- a/docs/Documentation/Anatomy-of-a-theme.markdown
+++ b/docs/Documentation/Anatomy-of-a-theme.markdown
@@ -142,7 +142,7 @@ Note that this is just a simple example, and normally adding a frame would be be
 
 ## Placement Files
 
-A theme can modify where shapes are rendered by including a _placement.info_ file at the root of the theme folder. The _placement.info_ file is an XML file. Here is an example:
+A theme can modify where shapes are rendered by including a `Placement.info` file at the root of the theme folder. The `Placement.info` file is an XML file. Here is an example:
 
     
     <Placement>

--- a/docs/Documentation/Basic-Orchard-Concepts.markdown
+++ b/docs/Documentation/Basic-Orchard-Concepts.markdown
@@ -6,17 +6,17 @@ Orchard is a Web CMS, which essentially aims at helping you build web sites from
 
 ## Content
 
-The 'C' in CMS means "content" so it would be fair to say that content is anything that the CMS manages. More precisely, content is everything in the site that has any information in it. For example, a blog post, a comment, a product and even the navigation menu or your company's logo are identifiable, individual pieces of content. If you were thinking at this moment that content is pretty much everything on the site you'd be right. If you were thinking that is pretty vague, you'd be right as well. We will get a lot more specific and distinguish between different kinds of content in following sections.
+The "C" in CMS means "content" so it would be fair to say that content is anything that the CMS manages. More precisely, content is everything in the site that has any information in it. For example, a blog post, a comment, a product and even the navigation menu or your company's logo are identifiable, individual pieces of content. If you were thinking at this moment that content is pretty much everything on the site you'd be right. If you were thinking that is pretty vague, you'd be right as well. We will get a lot more specific and distinguish between different kinds of content in following sections.
 
 ## Admin panel, Dashboard or back-end
 
-The admin panel (sometimes also called dashboard or back-end) is where you manage your site and its content. It is restricted to users who have the "Access admin panel" permission. This is the 'M' in CMS.
+The admin panel (sometimes also called dashboard or back-end) is where you manage your site and its content. It is restricted to users who have the "_Access admin panel_" permission. This is the "M" in CMS.
 
 ![](../Attachments/Basic-Orchard-Concepts/Dashboard.PNG)
 
 ## CMS
 
-The 'S' in CMS is for "System", which is not as vague and meaningless as it seems. It's important that a CMS manages content in a systematic way: this means that all content is managed homogeneously, which enables mutuality of resources.
+The "S" in CMS is for "System", which is not as vague and meaningless as it seems. It's important that a CMS manages content in a systematic way: this means that all content is managed homogeneously, which enables mutuality of resources.
 
 For example, you can manage blog posts, pages and products using common tools, and all of those can get comments, ratings or tagging from common modules. This gives you a more consistent experience and facilitates the creation of new types of content.
 
@@ -40,7 +40,7 @@ A content item is a single piece of content, often associated with a single URL 
 
 ## Content type
 
-Content items are instances of content types. Said differently, content types are classes of content items. We said in the previous section that examples of content items are pages, blog posts, and products. Those three examples also describe three content types: page, blog post and product. In other words what we call a blog post is just an item of type blog post.
+Content items are instances of content types. Said differently, content types are classes of content items. We said in the previous section that examples of content items are _pages_, _blog posts_, and _products_. Those three examples also describe three content types: _page_, _blog post_ and _product_. In other words what we call a blog post is just an item of type blog post.
 
 ## Content Part
 
@@ -56,13 +56,13 @@ There can be only one of each part on any given content type.
 
 Content fields are pieces of information that can be added to a content type. Content fields have a name and a type and are specific to a content type. There can be several of each field type on any given content type.
 
-For example, a Product content type can have a text field representing its Sku, a numeric field representing its price, and another numeric field representing its weight. Each of these fields probably only makes sense on a product.
+For example, a Product content type can have a text field representing its SKU, a numeric field representing its price, and another numeric field representing its weight. Each of these fields probably only makes sense on a product.
 
 > Note: it would be possible to create a product part with three properties that would be roughly equivalent to this set of fields. This would have the advantage of making it possible to transform any content type into a product. Each approach is a valid choice and Orchard allows for both.
 
 ## Module
 
-The various custom extensions that can be built for Orchard are typically built as modules. A module is a set of extensions for Orchard that are grouped under a single sub-folder of the Modules directory that can be found under the Orchard web site.
+The various custom extensions that can be built for Orchard are typically built as _modules_. A module is a set of extensions for Orchard that are grouped under a single sub-folder of the `Modules` directory that can be found under the Orchard web site.
 
 Optional modules for Orchard can be found in the Orchard Gallery (see the menu entry on top of this page).
 
@@ -70,7 +70,7 @@ Optional modules for Orchard can be found in the Orchard Gallery (see the menu e
 
 ## Feature
 
-A module can contain one or more features, which is a logical grouping of functionality that can be enabled or disabled individually. For example, a custom authentication module could have separate features for OpenID, FaceBook, LiveID, Twitter or Google authentication that can each be turned on or off.
+A module can contain one or more _features_, which is a logical grouping of functionality that can be enabled or disabled individually. For example, a custom authentication module could have separate features for OpenID, FaceBook, LiveID, Twitter or Google authentication that can each be turned on or off.
 
 Features can depend on each other, whether they are in the same module or not.
 
@@ -87,8 +87,8 @@ Here is an example of a manifest:
 	AntiForgery: enabled
 	Author: The Orchard Team
 	Website: http://orchardproject.net
-	Version: 1.8.1
-	OrchardVersion: 1.8
+	Version: 1.10.2
+	OrchardVersion: 1.9
 	Description: The comments system implemented by this module can be applied to arbitrary Orchard content types, such as blogs and pages. It includes comment validation and spam protection through the Akismet service.
 	Features:
     Orchard.Comments:
@@ -105,35 +105,33 @@ Here is an example of a manifest:
 
 # UI composition
 
-Orchard manages content that is composed from parts. It needs a mechanism that orchestrates the display while taking into account the composite nature of the content. This is why we talk about UI composition, as elementary bits and pieces of content need to be composed into a harmonious and consistent whole. Several concepts contribute to this UI composition.
+Orchard manages content that is composed from _parts_. It needs a mechanism that orchestrates the display while taking into account the composite nature of the content. This is why we talk about UI composition, as elementary bits and pieces of content need to be composed into a harmonious and consistent whole. Several concepts contribute to this UI composition.
 
 ## Theme
 
 When designing a web site, it is important to be able to modify the visual look of every single aspect of the site. Orchard provides a clean separation between the content management and the visual rendering of the content.
 
-A theme is a packaged look and feel for an Orchard site. It can consist of any combination of style sheets, images, layouts, templates and even custom code. It is even possible to create a theme that inherits from another, which is very useful if you are trying to make only small modifications on an existing theme.
+A theme is a packaged look and feel for an Orchard site. It can consist of any combination of style sheets, images, layouts, templates and even custom code. It is even possible to create a theme that inherits from another, which is very useful if you are trying to make only small modifications to an existing theme.
 
 ![The same site can be displayed differently by switching themes.](../Attachments/Basic-Orchard-Concepts/ThemeComparison.png)
 
 ## Layout
 
-A layout is a file in a theme that defines the general organization of the pages of the site that use it. A layout typically defines a set of zones where contents or widgets can be inserted.
+A _layout_ is a file in a theme that defines the general organization of the pages of the site that use it. A layout typically defines a set of _zones_ where contents or widgets can be inserted.
 
 ![The layout for the theme machine, with its various collapsible zones](../Attachments/Anatomy-of-a-theme/TheThemeMachineZoneScreenshot.PNG)
 
 ## Template
 
-Each content part, each field and each widget will need to be graphically represented in the front-end, transforming the data that it represents into a form that can be read by the users of the site. A template is the recipe that formats that data and transforms it into HTML for the browser to display. You can think of a template as plain HTML with well-defined "holes" where data gets inserted.
+Each content part, each field and each widget will need to be graphically represented in the front-end, transforming the data that it represents into a form that can be read by the users of the site. A _template_ is the recipe that formats that data and transforms it into HTML for the browser to display. You can think of a template as plain HTML with well-defined "holes" where data gets inserted.
 
-Here is an example of a template that displays the title from the Route part:
+Here is an example of a template that displays the title from the `Route` part:
 
-    
     <h1>@Model.Title</h1>
-
 
 ## Shape
 
-Before displaying something using a template, that something gets transformed into a shape, which is a very malleable object that contains all the information required in order to display it. Before getting rendered by templates, everything gets mapped into a tree of shapes that is a sort of abstract representation of the contents of the final page. The advantage of such trees of shapes is that any module can modify existing shapes or create new ones.
+Before displaying something using a template, that something gets transformed into a _shape_, which is a very malleable object that contains all the information required in order to display it. Before getting rendered by templates, everything gets mapped into a _tree of shapes_ that is a sort of abstract representation of the contents of the final page. The advantage of such trees of shapes is that any module can modify existing shapes or create new ones.
 
 The layout, zones, widgets and content parts all get represented as shapes as part of the rendering process.
 
@@ -141,16 +139,14 @@ One could imagine for example a Gravatar module that would add avatar icon shape
 
 ## Placement
 
-When rendering the collections of parts and fields -or any other shapes- that compose a page or content item, Orchard needs to know in what order to do so. Placement.info files are XML files that describe rules that can be used to determine what shapes go into what zones and in what order. This enables not only the rendering of each shape to be customized, but also the order in which they get rendered.
+When rendering the collections of parts and fields -or any other shapes- that compose a page or content item, Orchard needs to know in what order to do so. `Placement.info` files are XML files with rules that can be used to determine what shapes go into what zones and in what order. This enables not only the rendering of each shape to be customized, but also the order in which they get rendered.
 
 Here is an example of a placement file:
 
-    
     <Placement>
         <Place Parts_Map="Content:10"/>
         <Place Parts_Map_Edit="Content:7.5"/>
     </Placement>
-
 
 ## Zone
 
@@ -158,15 +154,15 @@ Zones are specific parts of a layout that can be customized by inserting widgets
 
 ## Widget
 
-A widget is a small fragment of UI that can be added to some or all pages of the site. Examples of widgets are tag clouds, maps, archives, a search form, or recent blog posts.
+A _widget_ is a small fragment of UI that can be added to some or all pages of the site. Examples of widgets are tag clouds, maps, archives, a search form, or recent blog posts.
 
 ![A few widgets](../Attachments/Basic-Orchard-Concepts/Widget.PNG)
 
 ## Layer
 
-A layer is a group of widgets (with their specific configuration, which includes their positioning -zone name and ordering-) that is activated by a specific rule.
+A _layer_ is a group of widgets (with their specific configuration, which includes their positioning -zone name and ordering-) that is activated by a specific rule.
 
-For example, the TheHomePage layer is activated by a rule that specifically selects the home page. The Default layer is always active no matter what page is displayed. The Authenticated layer is only active when users have identified themselves.
+For example, the `TheHomePage` layer is activated by a rule that specifically selects the home page. The `Default` layer is always active no matter what page is displayed. The `Authenticated` layer is only active when a user has identified themselves.
 
 When more than one layer is active on any given page, all the widgets from all those layers get displayed at the same time. Orchard orders them based on their position string.
 
@@ -174,12 +170,12 @@ When more than one layer is active on any given page, all the widgets from all t
 
 ## Users and roles
 
-In Orchard, users can be attributed roles, which can be seen as stereotypes of users. Permissions can then be attributed to roles in order to define who can do what on the site (more on this in the next section). Any user can have one or several roles.
+In Orchard, _roles_ can be assigned to users. Roles can be seen as stereotypes of users. Permissions can then be assigned to roles in order to define who can do what on the site (more on this in the next section). Any user can have one or several roles.
 
 Site owners can create their own roles but Orchard comes with built-in roles that should cover most sites' requirements:
 
 * Administrator: have full control over the site's settings and contents.
-* Editor: does not create content but edit and publish content created by authors.
+* Editor: does not create content, but edits and publishes content created by authors.
 * Moderator: validates user-created contents such as comments.
 * Author: writes and publishes his own content.
 * Contributor: writes content but does not necessarily have the rights to publish it.
@@ -190,19 +186,19 @@ Neither Anonymous nor Authenticated can be assigned to a user manually. Rather, 
 
 ## Privileges and Permissions
 
-All users don't have the same rights and privileges in Orchard: the site owner can choose who can create content, who can write or validate comments, etc. Rights and privileges are represented as permissions. In Orchard, permissions are granted to roles but are not explicitly denied. In other words if a user belongs to any role that has a given permission, he has that permission. To revoke a permission, you need to either remove a user from the role the permission has been granted to or you need to remove that permission for the whole role.
+All users don't have the same rights and privileges in Orchard: the site owner can choose who can create content, who can write or validate comments, etc. Rights and privileges are represented as _permissions_. In Orchard, permissions are granted to roles, but are not explicitly denied. In other words if a user belongs to any role that has a given permission, he has that permission. To revoke a permission, you need to either remove a user from the role the permission has been granted to or you need to remove that permission for the whole role.
 
-Some permissions are "effectively granted". This means that they have not been explicitly granted, but that they have been implied by another permission. For example, if you grant the site owner permission, you are implicitly granting all the other permissions.
+Some permissions are "effectively granted". This means that they have not been explicitly granted, but that they have been implied by another permission. For example, if you grant the _Site Owners Permission_, you are implicitly granting all the other permissions.
 
 ![](../Attachments/Basic-Orchard-Concepts/Permissions.PNG)
 
-Permissions, as well as their default settings for the built-in roles, are defined by modules. This means that if you build your own module, you can define specific permissions to accompany it.
+Permissions, as well as their default settings for the built-in roles, are defined by _modules_. This means that if you build your own module, you can define specific permissions to accompany it.
 
 ## Site owner
 
-The site owner, sometimes also called "super user" is a special user that is defined at setup time and that has all the rights on the site. It can be changed from the settings admin screen if you have the permission to do so.
+The site owner, sometimes also called "super user", is a special user that is defined at setup time and that has all the rights on the site. It can be changed from the _Settings_ admin screen if you have the permission to do so.
 
-There is a permission called "Site Owners Permission" that grants the same right and that is granted by default to only members of the Administrator role. We advise never to grant that permission to any other role.
+There is a permission called _Site Owners Permission_ that grants the same right and that is granted by default to only members of the _Administrator_ role. We advise never to grant that permission to any other role.
 
 # Development
 
@@ -214,27 +210,29 @@ ASP.NET MVC is the Web framework that Orchard is built on.
 
 ## Handler
 
-A handler is similar to an MVC filter in that it contains code that will execute for specific events of the request life-cycle. They are typically used to set-up data repositories or to do additional operations when something gets loaded.
+A _handler_ is similar to an MVC _filter_ in that it contains code that will execute for specific events of the request life-cycle. They are typically used to set-up data repositories or to do additional operations when something gets loaded.
 
 ## Driver
 
-Drivers are similar to MVC controllers, but they act at the level of a content part instead of at the level of the full request. They typically prepare shapes for rendering and handle post-backs from admin editors.
+_Drivers_ are similar to MVC _controllers_, but they act at the level of a content part instead of at the level of the full request. They typically prepare shapes for rendering and handle post-backs from admin editors.
 
 ## Record
 
-A record is a class that models the database representation of a content part. They are POCOs where each property must be virtual.
+A _record_ is a class that models the database representation of a content part. They are POCOs where each property must be virtual.
 
 ## Model
 
-What plays the part of the model for a content part is the part class itself. Some parts also define view models, in the form of strongly-typed classes or of more flexible dynamic shapes.
+The part of the _model_ for a content part is played by the part class itself. Some parts also define _view models_, in the form of strongly-typed classes or of more flexible dynamic shapes.
 
 ## Migration
 
-A migration is a description of the operations to execute when first installing a feature or when upgrading it from a version to the next. This enables smooth upgrades of individual features without data loss. Orchard includes a data migration framework.
+A _migration_ is a description of the operations to execute when first installing a feature or when upgrading it from one version to the next. This enables smooth upgrades of individual features without data loss. Orchard includes a data migration framework.
 
 ## Injection
-Inversion of Control, or injection, is widely used in Orchard. When any piece of code requires a dependency, it will typically demand the injection of one or several instances of a specific interface. The framework will take care of selecting, instantiating and injecting the right implementations at runtime.
+
+Inversion of Control, or _injection_, is widely used in Orchard. When any piece of code requires a dependency, it will typically demand the injection of one or several instances of a specific interface. The framework will take care of selecting, instantiating and injecting the right implementations at runtime.
 
 ### Change History
+
 * Updates for Orchard 1.8
     * 9-6-14: Updated all screen shots for setup, dashboard, content parts and modules/features.

--- a/docs/Documentation/Building-a-hello-world-module.markdown
+++ b/docs/Documentation/Building-a-hello-world-module.markdown
@@ -26,7 +26,7 @@ Once you have code generation enabled, open the Orchard command-line, and create
 
 # Modifying the Manifest
 
-You should now have a new HelloWorld folder under the Modules folder of your Orchard web site. In this folder, you'll find a module.txt file. Open it and customize it as follows:
+You should now have a new `HelloWorld` folder under the `Modules` folder of your Orchard web site. In this folder, you'll find a `Module.txt` file. Open it and customize it as follows:
 
     
     name: HelloWorld

--- a/docs/Documentation/Creating-1-n-and-n-n-relations.markdown
+++ b/docs/Documentation/Creating-1-n-and-n-n-relations.markdown
@@ -833,7 +833,7 @@ Of course, any variation from that naming scheme would make the binding fail.
 
 ## The Placement File
 
-For the parts to appear at all in the UI, we need to update our placement.info file:
+For the parts to appear at all in the UI, we need to update our `Placement.info` file:
 
     
     <Placement>

--- a/docs/Documentation/Creating-a-custom-field-type.markdown
+++ b/docs/Documentation/Creating-a-custom-field-type.markdown
@@ -27,7 +27,7 @@ Once the **Code Generation** feature has been enabled, you can type the followin
     codegen module CustomFields /IncludeInSolution:true
 
 
-This should create a new **CustomFields** folder under Modules, pre-populated with a few folders and files. For example, you may open the **module.txt** manifest file and modify it:
+This should create a new `CustomFields` folder under Modules, pre-populated with a few folders and files. For example, you may open the `Module.txt` manifest file and modify it:
 
     
     Name: CustomFields
@@ -51,7 +51,7 @@ We are defining two features here because this module will eventually contain mo
 
 # Modeling the Field
 
-Let's now create a **Fields** folder inside of our **CustomFields** folder and create the following **DateTimeField.cs** file in there:
+Let's now create a `Fields` folder inside of our `CustomFields` folder and create the following `DateTimeField.cs` file in there:
 
     
     using System;
@@ -92,7 +92,7 @@ The field is defined as a class that derives from `ContentField`, which gives us
 
 # Creating a View Model
 
-It is good practice (although not mandatory) to create one or several view models that will be used as the model in the admin template that we will use to render instances of our field. Let's create the following **DateTimeFieldViewModel.cs** file in a new **ViewModels** folder:
+It is good practice (although not mandatory) to create one or several view models that will be used as the model in the admin template that we will use to render instances of our field. Let's create the following `DateTimeFieldViewModel.cs` file in a new `ViewModels` folder:
 
     
     namespace CustomFields.DateTimeField.ViewModels {
@@ -116,7 +116,7 @@ This not only exposes the date and time as separate properties, it also has some
 
 This flexibility in rendering that we just introduced in the view model can be exposed as settings for the field. This way, administrators can configure fields on the content types they create in order to adapt them to their exact needs.
 
-Create a **Settings** folder and add the following **DateTimeFieldSettings.cs** file to it:
+Create a `Settings` folder and add the following `DateTimeFieldSettings.cs` file to it:
 
     
     namespace CustomFields.DateTimeField.Settings {
@@ -139,7 +139,7 @@ We have defined here an enumeration describing the possible values of our displa
 
 Exactly like a part, a field has a driver that will be responsible for handling display and editing actions on the field when it's been added to a content type.
 
-Create a **Drivers** folder and add the following **DateTimeFieldDriver.cs**:
+Create a `Drivers` folder and add the following `DateTimeFieldDriver.cs`:
 
     
     using System;
@@ -182,7 +182,7 @@ Create a **Drivers** folder and add the following **DateTimeFieldDriver.cs**:
                 var value = field.DateTime;
                 
                 return ContentShape("Fields_Custom_DateTime", // key in Shape Table
-                        field.Name, // used to differentiate shapes in placement.info overrides, e.g. Fields_Common_Text-DIFFERENTIATOR
+                        field.Name, // used to differentiate shapes in Placement.info overrides, e.g. Fields_Common_Text-DIFFERENTIATOR
                         // this is the actual Shape which will be resolved
                         // (Fields/Custom.DateTime.cshtml)
                         s =>
@@ -310,7 +310,7 @@ The second `Editor` method is the one that is called when the admin form is subm
 
 We need to write the views that will determine how our field is represented in admin and front-end UI.
 
-Create a **Fields** and an **EditorTemplates** directory under **Views**. Then create another **Fields** directory under EditorTemplates. In **Views/Fields**, create the following **Custom.DateTime.cshtml**:
+Create a `Fields` and an `EditorTemplates` directory under `Views`. Then create another `Fields` directory under EditorTemplates. In `Views/Fields`, create the following `Custom.DateTime.cshtml`:
 
     
     <p class="text-field"><span class="name">@Model.Name:</span> 
@@ -321,7 +321,7 @@ Create a **Fields** and an **EditorTemplates** directory under **Views**. Then c
 
 This code renders the name of the field, a colon and then the date and time according to the field's configuration.
 
-Now create a file of the same name under **Views/EditorTemplates/Fields** with the following contents:
+Now create a file of the same name under `Views/EditorTemplates/Fields` with the following contents:
 
     
     @model CustomFields.DateTimeField.ViewModels.DateTimeFieldViewModel
@@ -370,7 +370,7 @@ Now create a file of the same name under **Views/EditorTemplates/Fields** with t
 
 This template is registering a few styles and scripts (note that if other parts register the same files, they will still be rendered only once). Then, it defines the editor as a date picker and a time picker according to the field's configuration. The fields are regular text boxes that are unobtrusively enriched by date and time pickers using jQuery UI plug-ins.
 
-To specify the order and location where these templates will be rendered within the composed page, we need to add a placement.info file into the root of the module's directory:
+To specify the order and location where these templates will be rendered within the composed page, we need to add a `Placement.info` file into the root of the module's directory:
     
     <Placement>
         <Place Fields_Custom_DateTime_Edit="Content:2.5"/>
@@ -383,7 +383,7 @@ To specify the order and location where these templates will be rendered within 
 
 We are not quite done yet. We still need to take care of managing and persisting the settings for the field.
 
-Add the following **DateTimeFieldEditorEvents.cs** file to the **Settings** folder:
+Add the following `DateTimeFieldEditorEvents.cs` file to the `Settings` folder:
 
     
     using System.Collections.Generic;
@@ -425,7 +425,7 @@ Add the following **DateTimeFieldEditorEvents.cs** file to the **Settings** fold
 
 This is the equivalent of a driver, but for field settings. The first method gets the settings and determines the template to render, and the second updates the model with the values from the submitted form and then calls the first.
 
-The editor template for the field is defined by the following **DateTimeFieldSettings.cshtml** that you should create in a new **DefinitionTemplates** folder under **Views**:
+The editor template for the field is defined by the following `DateTimeFieldSettings.cshtml` that you should create in a new `DefinitionTemplates` folder under `Views`:
 
     
     @model CustomFields.DateTimeField.Settings.DateTimeFieldSettings
@@ -456,9 +456,9 @@ This template creates a label for the setting and then a drop-down that enables 
 
 # Updating the Project File
 
-If you are using Visual Studio, you should skip this section as your project file has already been updated, provided you saved all (CTRL+SHIFT+S). Otherwise, in order for the Orchard dynamic compilation engine to be able to pick up our new module's cs files, we need to add them to the **CustomFields.csproj** file. 
+If you are using Visual Studio, you should skip this section as your project file has already been updated, provided you saved all (CTRL+SHIFT+S). Otherwise, in order for the Orchard dynamic compilation engine to be able to pick up our new module's cs files, we need to add them to the `CustomFields.csproj` file. 
 
-Find the `<Content Include="Properties\AssemblyInfo.cs"/>` line in **CustomFields.csproj**. If you look at it then you will see that this is inside an `<ItemGroup>` element. After that end `</ItemGroup>` for that section add in this code:
+Find the `<Content Include="Properties\AssemblyInfo.cs"/>` line in `CustomFields.csproj`. If you look at it then you will see that this is inside an `<ItemGroup>` element. After that end `</ItemGroup>` for that section add in this code:
 
     <ItemGroup>
       <Compile Include="Drivers\DateTimeFieldDriver.cs" />
@@ -470,7 +470,7 @@ Find the `<Content Include="Properties\AssemblyInfo.cs"/>` line in **CustomField
 
 # Adding the Style Sheet
 
-Create a **Styles** directory and create the following **datetime.css**:
+Create a `Styles` directory and create the following `datetime.css`:
 
     
     html.dyn label.forpicker {
@@ -491,12 +491,12 @@ Create a **Styles** directory and create the following **datetime.css**:
 
 # Using the Field
 
-In order to be able to use the new field, you must first make sure that the **Orchard.ContentTypes** feature is enabled. Also enable our new **DateTimeField** feature under **Fields**. Once it is, you can click on **Manage content types** in the admin menu. Click **Create new type** and give it the name "Event". Click **Add** next to fields and type in "When" as the name of the field. Select our new **DateTime** field type as the type of the field.
+In order to be able to use the new field, you must first make sure that the `Orchard.ContentTypes` feature is enabled. Also enable our new `DateTimeField` feature under `Fields`. Once it is, you can click on **Manage content types** in the admin menu. Click **Create new type** and give it the name "Event". Click **Add** next to fields and type in "When" as the name of the field. Select our new `DateTime` field type as the type of the field.
 
-Now in the type editor, you should see our new **When** field, and you should be able to deploy its settings section by clicking the "**&gt;**" on its left:
+Now in the type editor, you should see our new `When` field, and you should be able to deploy its settings section by clicking the "**&gt;**" on its left:
 
 ![Configuring the field](../Attachments/Creating-a-custom-field-type/ConfiguringTheField.PNG)
-We chose to keep both date and time displayed. The settings for the field are also the opportunity to determine where the field will appear on the front end if you want to override the defaults. Let's skip that for now. Add the **Route** part so that our events can have a title, then hit Save.
+We chose to keep both date and time displayed. The settings for the field are also the opportunity to determine where the field will appear on the front end if you want to override the defaults. Let's skip that for now. Add the `Route` part so that our events can have a title, then hit Save.
 
 We can now add a new event by clicking **Create Event** in the admin menu. The editor that gets created for us has a when field with nice date and time pickers:
 

--- a/docs/Documentation/Creating-a-module-with-a-simple-text-editor.markdown
+++ b/docs/Documentation/Creating-a-module-with-a-simple-text-editor.markdown
@@ -58,9 +58,9 @@ You will use a code-generation command to create a commerce module. Enter the fo
     codegen module SimpleCommerce
 
 
-Open a Windows Explorer window and browse to the newly created _\inetpub\wwwroot\Orchard\Modules\SimpleCommerce_ folder. Open the _module.txt_ file using a text editor.
+Open a Windows Explorer window and browse to the newly created _\inetpub\wwwroot\Orchard\Modules\SimpleCommerce_ folder. Open the `Module.txt` file using a text editor.
 
-Change the description to "A simple commerce module". Change the description of the feature to be "A simple product part". Save the file and close it. The following example shows the complete _module.txt_ file after the changes.
+Change the description to "A simple commerce module". Change the description of the feature to be "A simple product part". Save the file and close it. The following example shows the complete `Module.txt` file after the changes.
 
     
     Name: SimpleCommerce
@@ -271,7 +271,7 @@ Update the _.csproj_ file to include the following line:
 
 The `Editor` method also creates a shape named `EditorTemplate`. The shape has a `TemplateName` property that instructs Orchard where to look for the rendering template. The code also specifies that the model for that template will be the part, not the shape (which would be the default).
 
-The placement of those parts within the larger front end or dashboard must be specified using a _placement.info_ file that is located at the root of the module. That file, like a view, can be overridden from a theme. Create the _placement.info_ file with the following contents:
+The placement of those parts within the larger front end or dashboard must be specified using a `Placement.info` file that is located at the root of the module. That file, like a view, can be overridden from a theme. Create the `Placement.info` file with the following contents:
 
     
     <Placement>
@@ -280,10 +280,10 @@ The placement of those parts within the larger front end or dashboard must be sp
     </Placement>
 
 
-Add the _placement.info_ file to the _.csproj_ file using the following line:
+Add the `Placement.info` file to the `.csproj` file using the following line:
 
     
-    <Content Include="placement.info" />
+    <Content Include="Placement.info" />
 
 
 # Building the Templates

--- a/docs/Documentation/Creating-custom-content-types.markdown
+++ b/docs/Documentation/Creating-custom-content-types.markdown
@@ -1,29 +1,29 @@
 
-Although Orchard includes the Page and Blog Post content types by default, it is very easy to create a custom content type (or even extend the definition of an existing content type) using the admin panel. By default, the **Content Types** feature is enabled. This feature must be enabled to create a custom content types. If needed, you can manually enable the feature in the **Manage Features** page.
+Although Orchard includes the _Page_ and _Blog Post_ content types by default, it is very easy to create a custom content type (or even extend the definition of an existing content type) using the admin panel. By default, the **Content Types** feature is enabled. This feature must be enabled to create a custom content types. If needed, you can manually enable the feature in the **Manage Features** page.
 
 ![](../Upload/screenshots_675/ContentTypes_enable.png)
 
-To create a content type, Click **Content Definition** and select the **Content Types** link in the admin panel.
+To create a content type, click **Content Definition** and select the **Content Types** link in the admin panel.
 
 ![](../Upload/screenshots/ContentTypes_startcustom.png)
 
-On this screen, you can see the available content types in the system.  Notice that it is possible to create and list content items of some of these types (such as "Page"), whereas others only allow you to edit the definition of the type here (such as Comments and Widgets, since these have a dedicated/custom admin experience for creating and listing these items instead). 
+On this screen, you can see the available content types in the system.  Notice that it is possible to create and list content items of some of these types (such as _Page_), whereas others only allow you to edit the definition of the type here (such as _Comments_ and _Widgets_, since these have a dedicated/custom admin experience for creating and listing these items instead). 
 
 ![](../Upload/screenshots_675/ContentTypes_manage2.png)
 
-If you click "List Items", to list the items of the "Page" type, you can see the available content items of this type ("Page") in the site, similar to the "Manage Content" screen in the admin menu).
+If you click **List Items**, to list the items of the _Page_ type, you can see the available content items of this type in the site, similar to the **Manage Content** screen in the admin menu).
 
 ![](../Upload/screenshots_675/manage_page_content2.png)
 
-You can also edit the definition of the Page type by clicking "Edit" for this type.
+You can also edit the definition of the _Page_ type by clicking **Edit** for this type.
 
 ![](../Upload/screenshots_675/edit_content_type_page.png)
 
-A content type in Orchard is made up of fields and parts.  An good overview of these concepts is described in [Basic Orchard Concepts](Basic-Orchard-Concepts).  A field is something specific to the type; for example, a Product type might have SKU and Price fields.  A part, however, is a reusable component that can be attached to one or more types.  For example, the Autoroute part gives a type the ability to be addressed on the front-end via a route/url.  In some ways, you can think of a type as _having_ fields, and _being_ made up of one or more parts.  This is actually reflected in the underlying code in Orchard as well.  To treat a blog post as a AutoroutePart and access it's AutoroutePart.Slug property, you would write something like this: post.As&lt;AutoroutePart&gt;.Slug.  Fortunately you don't have to write code to have fun with types and parts.  We are going to look at this in more detail by way of example in the next section.
+A content type in Orchard is made up of _fields_ and _parts_.  [Basic Orchard Concepts](Basic-Orchard-Concepts) provides a good overview of these concepts.  A _field_ is something specific to the type; for example, a _Product_ type might have _SKU_ and _Price_ fields.  A _part_, however, is a reusable component that can be attached to one or more types.  For example, the _Autoroute_ part gives a type the ability to be addressed on the front-end via a route/URL.  In some ways, you can think of a type as _having_ fields, and _being_ made up of one or more parts.  This is actually reflected in the underlying code in Orchard as well.  To treat a blog post as a `AutoroutePart` and access its `AutoroutePart.Slug` property, you would write something like this: `post.As<AutoroutePart>.Slug`.  Fortunately you don't have to write code to have fun with types and parts.  We are going to look at this in more detail by way of example in the next section.
 
 ### Defining a New Content Type
 
-Let's define a custom content type.  Suppose you wanted to define an "Event" type, for listing events with location and date fields.  To do this in the **Manage Content Types** screen, click on **Create new type**.
+Let's define a custom content type.  Suppose you wanted to define an _Event_ type, for listing events with location and date fields.  To do this in the **Manage Content Types** screen, click on **Create new type**.
 
 Type the name "Event" for the content type. The **Content Type Id** field is automatically populated with "Event" which you can keep.
 
@@ -33,47 +33,49 @@ Click **Add** to add a field.
 
 ![](../Upload/screenshots_675/ContentTypes_addfield.png)
 
-Currently Orchard only includes a single field type (TextField), but [more can be created](Creating-a-custom-field-type) as extensions to Orchard (for example, CheckBoxField, EmailField, TextAreaField, DateTimeField, etc), and a number of additional fields are available under **Gallery** > **Modules** as optional downloads.  Type "Location" for the name of the field, and click **Save**.  
+Currently Orchard only includes a single field type (`TextField`), but [more can be created](Creating-a-custom-field-type) as extensions to Orchard (for example, `CheckBoxField`, `EmailField`, `TextAreaField`, `DateTimeField`, etc), and a number of additional fields are available under **Gallery** > **Modules** as optional downloads.
+
+Type "Location" for the name of the field, and click **Save**.  
 
 ![](../Upload/screenshots/ContentTypes_addfieldname.png)
 
 ![](../Upload/screenshots/locationfieldsetting.png)
 
-The field is now listed in the Event type screen.
+The field is now listed in the _Event_ type screen.
 
 ![](../Upload/screenshots/add_field3.png)
 
 Go ahead and repeat the previous two steps to add a second field named "Date".
 
-To add a part to your type, click "Add" in the "Parts" section of the Event type.
+To add a part to your type, click **Add** in the **Parts** section of the _Event_ type.
 
-Here you can see the available parts in Orchard (as of the current release).  For our Event type, we want to be able to comment on the event ("Comments" part), tag the event ("Tags part"), access the event from the front-end via a URL/route ("Autoroute" part), add the event to the main menu ("Menu" part), and be able to publish the event immediately, on a schedule, or as a draft ("PublishLater" part).
+Here you can see the available parts in Orchard (as of the current release).  For our _Event_ type, we want to be able to comment on the event (`Comments` part), tag the event (`Tags` part), access the event from the front-end via a URL/route (`Autoroute` part), add the event to the main menu (`Menu` part), and be able to publish the event immediately, on a schedule, or as a draft (`PublishLater` part).
 
-Also add the "Common" part so that your items can appear in lists of content items.
+Also add the `Common` part so that your items can appear in lists of content items.
 
 ![](../Upload/screenshots_675/add_part.png)
 
-Types, fields and parts can have settings as well.  The specific settings that are available on the fields or parts is determined by the features that are activated in Orchard.  If we have enabled the "Indexing" feature, there is a setting to "Index this content type for search" and on each field, a setting to "Include in the index".  Select these options for the "Location" field of the custom "Event" type.  This will enable visitors of your site to search by location on the front-end (when the "Search" feature is enabled). Hit Save.
+Types, fields and parts can have _settings_ as well.  The specific settings that are available on the fields or parts is determined by the features that are activated in Orchard.  If we have enabled the _Indexing_ feature, there is a setting to "Index this content type for search" and on each field, a setting to "Include in the index".  Select these options for the "Location" field of the custom _Event_ type.  This will enable visitors of your site to search by location on the front-end (when the _Search_ feature is enabled).
+
+Hit **Save**.
 
 ![](../Upload/screenshots_675/content_type_field_settings.png)
 
 ![](../Upload/screenshots_675/includefieldinsearch.png)
 
-
-
-Now that we have defined our custom content type, let's create a new item of this type.  Notice the "Create New Event" link in "Manage Content Types".
+Now that we have defined our custom content type, let's create a new item of this type.  Notice the **Create New Event** link in **Manage Content Types**.
 
 ![](../Upload/screenshots_675/create_new_event.png)
 
-Similarly, there is a new admin menu link entitled **Event** under **New**.  Click either one of these links to create a new "Event" content item.
+Similarly, there is a new admin menu link entitled **Event** under **New**.  Click either one of these links to create a new _Event_ content item.
 
 ![](../Upload/screenshots/ContentTypes_newevent.png)
 
-We can see that the editor for our "Event" type has all the fields and parts we defined.  It has a **Title** because of the **TitlePart** and **Permalink** because of the **AutoroutePart**, a **Location** because of the fields we added, a **Tags** input from the **Tags** part, a **Show on main menu** checkbox from the **Menu** part, and the ability to enable comments from the **Comments** part.  The fact that we can **Publish Now**, **Publish Later** or **Save As Draft** is given by the **Publish Later** part.  Once you have filled in these fields, go ahead and publish the event.
+We can see that the editor for our _Event_ type has all the fields and parts we defined.  It has a **Title** because of the `TitlePart` and **Permalink** because of the `AutoroutePart`, a **Location** because of the fields we added, a **Tags** input from the `Tags` part, a **Show on main menu** checkbox from the `Menu` part, and the ability to enable comments from the `Comments` part.  The fact that we can **Publish Now**, **Publish Later** or **Save As Draft** is given by the `Publish Later` part.  Once you have filled in these fields, go ahead and publish the event.
 
 ![](../Upload/screenshots_675/ContentTypes_adddinner.png)
 
-Looking at the "Manage Content" screen in the Orchard admin panel, we can see our event item listed among the pages in the site!
+Looking at the **Manage Content** screen in the Orchard admin panel, we can see our event item listed among the pages in the site!
 
 ![](../Upload/screenshots_675/manage_content_event.png)
 
@@ -87,13 +89,13 @@ Let's try out the Search capability against our new content type.  Make sure you
 
 ![](../Upload/screenshots_675/search_index_event.png)
 
-We can tell the Search feature to query this field by going to the **Settings** admin screen and adding this field to the Search settings.
+We can tell the _Search_ feature to query this field by going to the **Settings** admin screen and adding this field to the Search settings.
 
 ![](../Upload/screenshots_675/ContentTypes_addeventlocation.png)
 
 On the front-end type a keyword that matches the location of your event.
 
-Search indexing has indexed our Location field and our event appears in search results as expected!
+Search indexing has indexed our "Location" field and our event appears in search results as expected!
 
 ![](../Upload/screenshots_675/ContentTypes_searchresults.png)
 

--- a/docs/Documentation/Creating-lists.markdown
+++ b/docs/Documentation/Creating-lists.markdown
@@ -112,7 +112,7 @@ Copy and paste the following code into the new file:
 
 This template looks at the name of the field, and if the name is "Buy", the template changes the rendering to be a link to the value of the field.
 
-In addition to customizing how fields render in a custom content type, you can change what's displayed and where it's displayed by using a _placement.info_ file. If you already have a _placement.info_ file at the root of your site's current theme folder, edit it and add the **Match** element shown in the following example before the `&lt;/Placement&gt;` closing tag. If you don't already have a _placement.info_ file, create a new file and add the following content:
+In addition to customizing how fields render in a custom content type, you can change what's displayed and where it's displayed by using a `Placement.info` file. If you already have a `Placement.info` file at the root of your site's current theme folder, edit it and add the **Match** element shown in the following example before the `&lt;/Placement&gt;` closing tag. If you don't already have a `Placement.info` file, create a new file and add the following content:
 
     
     <Placement>
@@ -139,7 +139,7 @@ When the details are displayed, the placement file specifies that the body of th
 
 ![](../Upload/screenshots_675/bookreview_details_customrender_675.png)
 
-When the whole list of books is displayed, you want to display a more abbreviated view, such as the title and summary only for each book. To suppress the display of the comment count, the tags, the metadata and the fields, the _placement.info_ file sends those shapes to the "Nowhere" zone. The "Nowhere" zone is not actually a defined Orchard zone, it is simply a standard way in **.info** files of suppressing elements you want to hide by sending them to an undefined zone. The summary is sent to the **Content** zone. Click the **Book Reviews** menu entry to view the updated rendering of your list of reviews. 
+When the whole list of books is displayed, you want to display a more abbreviated view, such as the title and summary only for each book. To suppress the display of the comment count, the tags, the metadata and the fields, the `Placement.info` file sends those shapes to the "Nowhere" zone. The "Nowhere" zone is not actually a defined Orchard zone, it is simply a standard way in `.info` files of suppressing elements you want to hide by sending them to an undefined zone. The summary is sent to the **Content** zone. Click the **Book Reviews** menu entry to view the updated rendering of your list of reviews. 
 
 ![](../Upload/screenshots_675/bookreview_list_placementinfo_675.png)
 

--- a/docs/Documentation/Customizing-Orchard-using-Designer-Helper-Tools.markdown
+++ b/docs/Documentation/Customizing-Orchard-using-Designer-Helper-Tools.markdown
@@ -25,7 +25,7 @@ The **Shape Tracing** pane displays the following information:
 
 * **Shape**. Information about the shape and the template to render the shape. Includes the option of creating alternates as described later in this article.
 * **Model**. Information about the model for this shape.
-* **Placement**. The _placement.info_ file.
+* **Placement**. The `Placement.info` file.
 * **Template**. The code in the template file
 * **HTML**. The HTML for rendering this shape.
 

--- a/docs/Documentation/Developer-FAQ.markdown
+++ b/docs/Documentation/Developer-FAQ.markdown
@@ -22,8 +22,8 @@ The projects in the "Modules" folder are physically located under the "src\Orcha
 
 The Core modules are physically located under the "\src\Orchard.Web\Core" folder. 
 
-## What is a Module.txt file?
-This is the module manifest. It is a YAML-format file. You can learn more about module.txt in the [manifest files guide](manifest-files).
+## What is a `Module.txt` file?
+This is the module manifest. It is a YAML-format file. You can learn more about `Module.txt` in the [manifest files guide](manifest-files).
 
 ## What is the AdminMenu.cs file?
 This file has an implementation of the Orchard interface called `INavigationProvider`. It lets modules hook themselves into the admin menu in the backend. This is typically where you declare what links should your module inject into the Admin menu and what controller actions these links invoke.

--- a/docs/Documentation/First-steps-into-Orchard.markdown
+++ b/docs/Documentation/First-steps-into-Orchard.markdown
@@ -20,7 +20,7 @@ The **administrator** has access to a few more aspects of the website:
 
     ![](../Attachments/First-Steps-Into-Orchard/Orchard-Installation.png)
 
-1. Of course, as users, they can see the front-end as well
+1. Of course, as users, they can see the front-end as well.
 
 1. They can open the [dashboard](Getting-around-the-dashboard) (aka control panel/back-end) for two reasons:
     1. [Configure the website](Getting-Started): Edit settings around the behavior and look of the website (or install/disable/upgrade them)
@@ -37,23 +37,23 @@ The **administrator** has access to a few more aspects of the website:
 
 ### Designer
 The **designer** can modify the [look of the website](Previewing-and-applying-a-theme). He can edit the settings of an existing theme (if provided) or create one.
-A **[theme](Anatomy-of-a-theme)** is everything that plays in the visual representation of the website. It is sometimes called skin or template. It transforms the **content** (user-generated data) into HTML that can be displayed in a browser. Eg: When you write a blog post, the theme defines where and how to show the menu, title, body, comments, etc.
+A **[theme](Anatomy-of-a-theme)** is everything that is involved in the visual representation of the website. It is sometimes called _skin_ or _template_. It transforms the **content** (user-generated data) into HTML that can be displayed in a browser. E.g.: When you write a blog post, the theme defines where and how to show the menu, title, body, comments, etc.
 
 Depending on how much customization is required, the designer may [edit some or all elements of the theme](Customizing-the-default-theme). These elements are of the following types:
 
-* Documents defining the **layout** and its zones: This is the overall representation of a page on the website (without any actual content). Eg: It says if the website should have one, two or three columns. So, a **zone** is a container that is part of the layout and ready to receive any content. Note that a flexible theme (like the one provided by Orchard) can adapt to hide empty zones. So, although Figure 6 shows a lot of zones, most of them will not be visible on actual pages because they aren't being used.
+* Templates defining the **layout** and its zones: This is the overall representation of a page on the website (without any actual content). E.g.: it determines if the website should have one, two or three columns. So, a **zone** is a container that is part of the layout and ready to receive any content. Note that a flexible theme (like the one provided by Orchard) can adapt to hide empty zones. So, although Figure 6 shows a lot of zones, most of them will not be visible on actual pages because they aren't being used.
 
     ![](../Attachments/First-Steps-Into-Orchard/ThemeZonePreview.png)
     
-* **Views**: Visual representation of a specific content. A view is typically a file with the extension .CSHTML or .ASPX. It provides the HTML code to use when displaying a specific type of content. So, a page with many contents (menu, blog post, comments, etc) will be created by using the composition of all the relevant individual views.
+* **Views**: Visual representation of specific content. A view is typically a file with the extension `.cshtml` or `.aspx`. It provides the HTML code to use when displaying a specific type of content. So, a page with a lot of contents (menu, blog post, comments, etc) will be created by using the composition of all the relevant individual views.
 
     ![](../Attachments/First-Steps-Into-Orchard/Orchard-ShapesOutlined.png)
 
-* **Stylesheets**, **Javascript** and Media files: They are used to modify the look defined in the views. They are files like "Site.css", jQuery or the images for background, borders and icons
+* **Stylesheets**, **Javascript** and **Media** files: They are used to modify the look defined in the views. They are files like `Site.css`, jQuery or the images for background, borders and icons.
 
-* **[Widget](Managing-widgets)**: A web page typically presents one main content (like a blog post), but it often also has small pieces of information on the sides. Eg: a tag cloud, a list of recent posts, a twitter feed, etc
+* **[Widget](Managing-widgets)**: A web page typically presents one main content (like a blog post), but it often also has small pieces of information on the sides. E.g.: a tag cloud, a list of recent posts, a twitter feed, etc.
 
-* Layers and the binding between content to specific zones: A **layer** is like the description of a group of pages. Once defined, you can tell where to put each content (or widget). Eg: A layer grouping all the blog posts can be defined, then we can make a Tag cloud widget appear on the side.
+* Layers and the binding between content to specific zones: A **layer** is like the description of a group of pages. Once defined, you can tell where to put each content (or widget). E.g.: A layer grouping all the blog posts can be defined, then we can make a Tag cloud widget appear on the side.
 
     ![](../Attachments/First-Steps-Into-Orchard/Orchard-WidgetLayers.png)
 
@@ -64,20 +64,20 @@ The **developer** has a complete insight of the architecture of Orchard and can 
 
 Orchard is organized in modules. Each **module** provides a building block (aka add on/plugin) to the website with a high level distinct goal. For example, you can have:
 
-* Extension module: Adds some (low-level) features that will benefit the website. Eg: Ability to [search your content](Search-and-indexing) or to [use an external editor to write blog posts (like Live Writer)](Blogging-with-LiveWriter)
+* Extension module: Adds some (low-level) features that will benefit the website. E.g.: Ability to [search your content](Search-and-indexing) or to [use an external editor to write blog posts (like Live Writer)](Blogging-with-LiveWriter).
 
-* Content module: Adds everything (code and visual) required to view/edit some type of content (like blog posts)
+* Content module: Adds everything (code and visual) required to view/edit some type of content (like blog posts).
 
-* Widget module: Adds a small visual content that can be displayed on the side of existing content modules (like a Tag cloud next to a blog)
+* Widget module: Adds a small visual element that can be displayed alongside existing content modules (like a Tag cloud next to a blog).
 
-* Element module: Adds a small contained element for use in the Orchard.Layouts module, a core module that lets you design page layouts in the browser.
+* Element module: Adds a small contained element for use in the `Orchard.Layouts` module, a core module that lets you design page layouts in the browser.
 
-* Theme module: Changes the look of existing content modules (This is what the designer would typically create)
+* Theme module: Changes the look of existing content modules (this is what the designer would typically create).
 
-* All the above: A module can have many extensions, content types, widgets and themes all in one package 
+* All the above: A module can have many extensions, content types, widgets and themes all in one package.
 
 Orchard is designed to be highly extensible; this means that almost anything that you interact with can be extended, replaced or disabled.
-Out of the box, Orchard comes with a number of modules to provide a good user/administrator experience; but a designer/developer can change them or [create more](Getting-Started-with-Modules). It is also possible to [share your modules](Packaging-and-sharing-a-module) with the Orchard community and to [install modules](Installing-and-upgrading-modules) developed by others.
+Out of the box, Orchard comes with a number of modules to provide a good user/administrator experience, but a designer/developer can change them or [create more](Getting-Started-with-Modules). It is also possible to [share your modules](Packaging-and-sharing-a-module) with the Orchard community and to [install modules](Installing-and-upgrading-modules) developed by others.
 
 Orchard comes with only one theme (called "[The Theme Machine](Anatomy-of-a-theme)"). However, it has enough zones to allow various arrangements. This is important because a site can only have one theme active at a time. This means the theme must be flexible enough to allow pages to have different layouts. If you are not satisfied, you can copy it and add more zones.
 
@@ -88,13 +88,12 @@ In order to fill your website, Orchard allows you to edit and display content. I
 
 * **Content:** Data that is typically displayed on the front-end website. I use this term as a generic way of calling anything that is user-generated.
 
-
 * **[Content Type &amp; Item](Creating-custom-content-types)**: A **content type** is like a dynamic class; it defines a structure of data for a specific type of content. That structure can be changed, even by the administrator. A **content item** is an instance of content type. So, BlogPost can be a content type, and when you write one, that one is a content item.
 
-* **[Content Part](Writing-a-content-part)**: Because many content types share many aspects; these aspects can be created independently and reused in each content type. That's what a content part is. Eg: A blog post can have comments; a photo can also have comments; so, instead of implementing the "comments" feature twice, we can create it as a content part and reuse it for both content types.
+* **[Content Part](Writing-a-content-part)**: Because many content types share many aspects; these aspects can be created independently and reused in each content type. That's what a content part is. E.g.: A blog post can have comments; a photo can also have comments; so, instead of implementing the "comments" feature twice, we can create it as a content part and reuse it for both content types.
 
-* **[Content Field](Creating-a-custom-field-type)**: In the same spirit of reusability, we can have smaller types that must behave in a certain way. Eg: Most content types will need Date, phone number, email address, etc. They aren't simple properties since we can attach some behavior (like validation rules) but they aren't content parts either (too "small").
-* **Record**: In order to be able to save a content type/part (in a SQL database), it needs to be "linked" to a record. It is a class with all the properties that should be saved. Eg: A Map part must save its coordinates (Latitude &amp; Longitude), so it will be linked to a record with these two properties; and Orchard will do the rest to load/save it. You will not have to deal with records unless you [develop your own module](Getting-Started-with-Modules). But it is useful to understand this concept in case you encounter it.
+* **[Content Field](Creating-a-custom-field-type)**: In the same spirit of reusability, we can have smaller types that must behave in a certain way. E.g.: Most content types will need Date, phone number, email address, etc. They aren't simple properties since we can attach some behavior (like validation rules) but they aren't content parts either (too "small").
+* **Record**: In order to be able to save a content type/part (in a SQL database), it needs to be "linked" to a record. It is a class with all the properties that should be saved. E.g.: A Map part must save its coordinates (Latitude &amp; Longitude), so it will be linked to a record with these two properties; and Orchard will do the rest to load/save it. You will not have to deal with records unless you [develop your own module](Getting-Started-with-Modules). But it is useful to understand this concept in case you encounter it.
 
 Note that a content type can only have one of each kind of content parts. But it can have many fields of the same kind. The reason is in the semantic meaning of these concepts. For example, a blog post can only have one commenting aspect and it can have many dates (creation date, last update date, etc.).
 

--- a/docs/Documentation/Getting-Started-with-Modules-Part-1.markdown
+++ b/docs/Documentation/Getting-Started-with-Modules-Part-1.markdown
@@ -26,7 +26,7 @@ If you get stuck or need some support at any point in the course there are sever
   1. Open an issue on the [Orchard Doc GitHub repo](https://github.com/OrchardCMS/OrchardDoc/issues).
 
 ## Setting up
-First things first, you need to follow the [setting up for a lesson](Setting-up-for-a-lesson) guide.
+First things first. You need to follow the [setting up for a lesson](Setting-up-for-a-lesson) guide.
 
 This will take you through the initial steps to set up your dev environment and pull a fresh copy of the source code down. When you've completed it please use your back button to come back to this course.
        
@@ -50,13 +50,13 @@ Now that you've completed all of the setup tasks you will have a fresh copy of O
 The rest of this part of the course will walk you through the process required to scaffold an empty module and then build a simple `Widget` inside of it.
 
 ## Command line scaffolding with Orchard.exe
-You should now be looking at Visual Studio. Down the side, in your Solution Explorer window you will see many files and folders. 
+You should now be looking at Visual Studio. Down the side, in your **Solution Explorer** window you will see many files and folders. 
 
 The first step to take is to collapse all of the projects down. Its a long list and we need to be able to see an overview of the solution so we can start working with it. You don't need to collapse these individually by hand however:
 
-  1. If your Solution Explorer window is not visible click `View`, `Solution Explorer`. 
+  1. If your Solution Explorer window is not visible click **View**, **Solution Explorer**. 
   
-  1. Click the `Collapse All` icon in the toolbar along the top of the solution explorer. It looks like this:
+  1. Click the **Collapse All** icon in the toolbar along the top of the solution explorer. It looks like this:
      
     ![](../Attachments/getting-started-with-modules-part-1/collapse-all.png)
 
@@ -68,11 +68,11 @@ There is a utility that is packaged with each copy of Orchard which will let us 
 
 To scaffold a new module:
 
-  1. Press the `Save All` button (or press `Ctrl-Shift-S`). Its a good practice to always save before using the command line utility. Many of its commands will make changes to your solution and if you have unsaved changes you will get merge conflicts.
+  1. Press the **Save All** button (or press `Ctrl-Shift-S`). It's a good practice to always save before using the command line utility. Many of its commands will make changes to your solution and if you have unsaved changes you will get merge conflicts.
   
   1. In the Solution Explorer, scroll down to the `Orchard.Web` project. It should be the very last project in the solution.
   
-  1. Right click on the `Orchard.Web` project and choose `Open Folder in File Explorer`:
+  1. Right click on the `Orchard.Web` project and choose **Open Folder in File Explorer**:
      
      ![](../Attachments/getting-started-with-modules-part-1/open-orchard-web.png)
   
@@ -96,13 +96,13 @@ To scaffold a new module:
      
      This will activate the code generation features of `orchard.exe`. 
      
-     > **Note:** If you get an error saying `No command found matching arguments "feature enable Orchard.CodeGeneration"` then you didn't follow the steps in the [setting up for a lesson](Setting-up-for-a-lesson) guide. You need to run the solution and go through the Orchard Setup screens before this command is available.
+     > **Note:** If you get an error saying '_No command found matching arguments "feature enable Orchard.CodeGeneration"_' then you didn't follow the steps in the [setting up for a lesson](Setting-up-for-a-lesson) guide. You need to run the solution and go through the Orchard Setup screens before this command is available.
      
      The code generation command that we will be using is `codegen module`.
      
   1. Type `help codegen module` and press enter to see the syntax for this command. To see details about all of the commands available type `help commands`. 
   
-    Like the rest of Orchard CMS, the orchard.exe command shell is extendable. The total number of commands available can vary depending on what features / modules you have loaded. In a future tutorial we will look at extending orchard.exe with our own commands.
+    Like the rest of Orchard CMS, the `orchard.exe` command shell is extendable. The total number of commands available can vary depending on what features / modules you have loaded. In a future tutorial we will look at extending `orchard.exe` with our own commands.
     
   1. Scaffold the module by entering the following command: `codegen module Orchard.LearnOrchard.FeaturedProduct`. 
   
@@ -110,13 +110,13 @@ To scaffold a new module:
      
   1. Close the Orchard command-line window.
   
-  1. This has now created a new, empty module in the file system. Switching back to Visual Studio should show you the `File Modification Detected` dialog:
+  1. This has now created a new, empty module in the file system. Switching back to Visual Studio should show you the **File Modification Detected** dialog:
     
     ![](../Attachments/getting-started-with-modules-part-1/reload-solution.png)
     
-    Click `Reload`.
+    Click **Reload**.
     
-    > **Note:** If you had unsaved changes in your Solution file then click the `Dismiss` option and add the project manually. In the Solution Explorer, `Right click` on the `Modules` folder. Choose `Add`, `Existing Project`, then navigate to `.\src\Orchard.Web\Modules\Orchard.LearnOrchard.FeaturedProduct\`, select `Orchard.LearnOrchard.FeaturedProduct.csproj` and press `Open`.
+    > **Note:** If you had unsaved changes in your Solution file then click the **Dismiss** option and add the project manually. In the Solution Explorer, _Right click_ on the `Modules` folder. Choose **Add**, **Existing Project**, then navigate to `.\src\Orchard.Web\Modules\Orchard.LearnOrchard.FeaturedProduct\`, select `Orchard.LearnOrchard.FeaturedProduct.csproj` and press **Open**.
 
 The basic framework for a module now exists inside the modules section of your solution:
 
@@ -129,14 +129,14 @@ If you are at the stage of wanting to build modules for Orchard then you should 
   
   - **Widgets**: You can also make a content type that works as a `Widget`. The `Widget` is a special variation of content type which can be placed into one of the many `Zones` a template defines. It's manageable via the admin dashboard at run-time. Content types can opt-in to this system by configuring their `Stereotype` setting to `Widget`.  
   
-  - **Content Item**: This is an instance of a specific content type. When you create a new `Page` in Orchard and fill it with content that is a `Content Item` with a `Content Type` of `Page`.
+  - **Content Item**: This is an instance of a specific content type. When you create a new `Page` in Orchard and fill it with content, you have created a _Content Item_ with a _Content Type_ of `Page`.
   
-  - **Content Part**: A small module providing some specific functionality. The `Content Type` is made up by attaching various `Content Parts` to it. For example you could have a comments content part. It just manages a block of comments for whatever it is attached to. The same comments content part could be attached to a `Page` content type, a `Blog` content type, or within a `Widget`.
+  - **Content Part**: A small module providing some specific functionality. The _Content Type_ is made up by attaching various _Content Parts_ to it. For example you could have a _comments_ content part. It just manages a block of comments for whatever it is attached to. The same comments content part could be attached to a `Page` content type, a `Blog` content type, or within a `Widget`.
 
 ## What we will be building
 As you might have guessed from the module name, we are going to build a very simple featured product module. This first step into extending Orchard will be a small one. 
 
-The featured product module will be a `Widget` which shows a static message listing the featured product with a link to that page. It's not going to have any configurable settings behind it so we won't need to look at the database side of things yet. It's not going to be powered by an actual product system. A `Widget` is a great starting pointing point because it doesn't need to worry about menu settings, titles, URLs or integration into the admin dashboard.
+The featured product module will be a `Widget` which shows a static message listing the featured product with a link to that page. It's not going to have any configurable settings behind it so we won't need to look at the database side of things yet. It's not going to be powered by an actual product system. A `Widget` is a great starting point because it doesn't need to worry about menu settings, titles, URLs or integration into the admin dashboard.
 
 It will be a simple banner which you can display on your site by adding a widget via the admin dashboard. This will be enough to show the core concepts of a module. We will come back and make improvements in the next three parts of this course.
 
@@ -147,19 +147,19 @@ The content part class is the core data structure. When you scaffolded the modul
 
 ![](../Attachments/getting-started-with-modules-part-1/add-contentpart-class.png)
 
-  1. `Right click` on the `Models` folder.
+  1. **Right click** on the `Models` folder.
   
-  1. Choose `Add`
+  1. Choose **Add**
   
-  1. Choose `Class...`
+  1. Choose **Class...**
 
-  1. In the `Name:` field type `FeaturedProductPart`
+  1. In the **Name:** field type `FeaturedProductPart`
   
-  1. Click `Add`
+  1. Click **Add**
   
 Your new class will be created and opened up in the Visual Studio editor.
 
-> **Important note:** In order for Orchard to recognize Content Part classes they must be in a namespace ending `.Models`. 
+> **Important note:** In order for Orchard to recognize Content Part classes they must be in a namespace ending in `.Models`. 
 
 > Because you already added this class within the `Models` folder the namespace is automatically wrapped around your class. In the future, when you're making your own classes don't forget to ensure that you follow this namespace structure.
 
@@ -187,17 +187,17 @@ That's all you need to do for your first `ContentPart` class. Your `FeaturedProd
     }
 
 ## Data migrations
-When your module is enabled in the admin dashboard Orchard will execute a data migration process. The purpose of the data migration is to register a list of the features contained in the module and any data it uses.
+When your module is enabled in the admin dashboard, Orchard will execute a data migration process. The purpose of the data migration is to register a list of the features contained in the module and any data it uses.
 
 We aren't going to use this yet, but the migration is also used for upgrades. As you work on your modules you will want to add and remove bits. The data migration class can make changes and you can transform your existing data to meet your new requirements.
 
 The data migration class can be created by hand, following a similar process as the last section but we can also scaffold it with the `orchard.exe` command line. Let's dive back in to the command line and add a data migration class to the module.
 
-  1. Press the `Save All` button (or press `Ctrl-Shift-S`). Its a good practice to always save before using the command line utility. Many of its commands will make changes to your solution and if you have unsaved changes you will get merge conflicts.
+  1. Press the **Save All** button (or press `Ctrl-Shift-S`). Its a good practice to always save before using the command line utility. Many of its commands will make changes to your solution and if you have unsaved changes you will get merge conflicts.
   
   1. In the Solution Explorer, scroll down to the `Orchard.Web` project. It should be the very last project in the solution.
   
-  1. Right click on the `Orchard.Web` project and choose `Open Folder in File Explorer`:
+  1. Right click on the `Orchard.Web` project and choose **Open Folder in File Explorer**:
      
      ![](../Attachments/getting-started-with-modules-part-1/open-orchard-web.png)
   
@@ -221,7 +221,7 @@ The data migration class can be created by hand, following a similar process as 
      
   1. Type `help codegen datamigration` and press enter to see the syntax for this command. To see details about all of the commands available type `help commands`. 
   
-    Like the rest of Orchard CMS, the orchard.exe command shell is extendable. The total number of commands available can vary depending on what features / modules you have loaded. In a future tutorial we will look at extending orchard.exe with our own commands.
+    Like the rest of Orchard CMS, the `orchard.exe` command shell is extendable. The total number of commands available can vary depending on what features / modules you have loaded. In a future tutorial we will look at extending `orchard.exe` with our own commands.
     
   1. Scaffold the data migration class by entering the following command: `codegen datamigration Orchard.LearnOrchard.FeaturedProduct`.
   
@@ -229,17 +229,17 @@ The data migration class can be created by hand, following a similar process as 
   
   1. This has now created a new data migration the file system called `Migrations.cs`. It will be in the root folder of your module. 
   
-     Switching back to Visual Studio should show you the `File Modification Detected` dialog:
+     Switching back to Visual Studio should show you the **File Modification Detected** dialog:
     
     ![](../Attachments/getting-started-with-modules-part-1/reload-solution.png)
     
-    Click `Reload`.
+    Click **Reload**.
     
-    > **Note:** If you had unsaved changes in your Solution file then click the `Dismiss` option and add the class manually. In the Solution Explorer, `right click` on the `Orchard.LearnOrchard.FeaturedProduct` folder. Choose `Add`, `Existing Item`, then navigate to `.\src\Orchard.Web\Modules\Orchard.LearnOrchard.FeaturedProduct\`, select `Migrations.cs` and press `Add`.
+    > **Note:** If you had unsaved changes in your Solution file then click the **Dismiss** option and add the class manually. In the Solution Explorer, _right click_ on the `Orchard.LearnOrchard.FeaturedProduct` folder. Choose **Add**, **Existing Item**, then navigate to `.\src\Orchard.Web\Modules\Orchard.LearnOrchard.FeaturedProduct\`, select `Migrations.cs` and press **Add**.
 
 Now you have a `Migrations.cs` file in the root folder of your module's project. By default it has an empty method called `Create()` which returns an `int`. For the moment, returning a value of `1` is fine. It's the version number of your data migration and we will look into it in more detail later in this course.
 
-As discussed earlier the `Widget` is just a `ContentType` with a `Stereotype` of `Widget`. A `ContentType` is basically just a collection of `ContentPart`s. Every `ContentType` should contain the `CommonPart` which gives you the basics like the owner and date created fields. We will also add the `WidgetPart` so it knows how to widget. Finally we also include the content part we are building, `FeaturedProductPart`.
+As discussed earlier, the `Widget` is just a `ContentType` with a `Stereotype` of `Widget`. A `ContentType` is basically just a collection of `ContentPart`s. Every `ContentType` should contain the `CommonPart` which gives you the basics like the owner and date created fields. We will also add the `WidgetPart` so it knows how to widget. Finally we also include the content part we are building, `FeaturedProductPart`.
 
 Let's update the `Create()` method to implement these plans:
 
@@ -265,11 +265,11 @@ Let's update the `Create()` method to implement these plans:
   
     ![](../Attachments/getting-started-with-modules-part-1/datamigrations-unknownnamespace.png)
    
-  1. `Right click` on your `References` and choose `Add Reference...`
+  1. _Right click_ on your **References** and choose **Add Reference...**
    
      ![](../Attachments/getting-started-with-modules-part-1/datamigrations-addreference.png)
      
-  1. Click the `Projects` tab on the left. Scroll down until you can see `Orchard.Widgets` in the list. `Hover` your mouse over it and a checkbox will appear. Click the checkbox for  `Orchard.Widgets`. Click `OK`.
+  1. Click the **Projects** tab on the left. Scroll down until you can see `Orchard.Widgets` in the list. _Hover_ your mouse over it and a checkbox will appear. Click the checkbox for  `Orchard.Widgets`. Click **OK**.
   
      ![](../Attachments/getting-started-with-modules-part-1/datamigrations-orchardwidgets.png)
      
@@ -279,7 +279,7 @@ Let's update the `Create()` method to implement these plans:
      
      You will now have the correct `using Orchard.Widgets.Models` option presented to you. Select it.
 
-  1. Save your progress so far by clicking the `Save all` button (or press `Ctrl-Shift-S`).
+  1. Save your progress so far by clicking the **Save all** button (or press `Ctrl-Shift-S`).
   
 That's all for the data migration, your `Migrations.cs` should now look like this:
 
@@ -313,7 +313,7 @@ In order to let Orchard know that we have this dependency we need to record it i
 
 We will look at the `Module.txt` manifest file again in more detail in part 4 of this course, for now we just need to go in and record the dependency we have created with `Orchard.Widgets`. 
 
-It is important to record this information as soon as we make a dependency on a module. If we don't record the information then your module can cause exceptions for your users at run-time. You really need to get into the habit of doing it straight away because not only are they are easy to forget but if you have the module that you depend on already enabled you won't see any errors but your users will.
+It is important to record this information as soon as we make a dependency on a module. If we don't record the information then your module can cause exceptions for your users at run-time. You really need to get into the habit of doing it straight away, because not only are they are easy to forget but if you have the module that you depend on already enabled you won't see any errors but your users will.
 
 Lets update the manifest now to include the `Orchard.Widgets` dependency:
 
@@ -332,7 +332,7 @@ Lets update the manifest now to include the `Orchard.Widgets` dependency:
                  Description: Description for feature Orchard.LearnOrchard.FeaturedProduct.
                  Dependencies: Orchard.Widgets
                  
-      The indentation is important as creates hierarchy within a YAML document. Indent the line with 8 spaces.
+      The indentation is important as it creates hierarchy within a YAML document. Indent the line with 8 spaces.
       
 ## How is all this magic working?
 So far the `ContentPart` class has been magically detected as long as it uses the `.Model` namespace, now the data migration is automatically detected just for deriving from `DataMigrationImpl`. How is all of this happening?
@@ -346,7 +346,7 @@ Later on we will use Autofac's dependency injection which let us automatically g
 ## Content part driver
 Everything you see in Orchard is composed from `Shapes`. If you don't know about shapes you can learn more about them in the [accessing and rendering shapes](Accessing-and-rendering-shapes) guide. 
 
-A content part driver is a class that composes the shapes that should be used to view and edit content parts. Drivers live in their own folder called `Drivers`. A basic driver class will contain three methods; a display driver for viewing a content part in the front end, an editor driver for presenting an editor form in the admin dashboard and an update method to handle changes submitted from the editor form.
+A content part driver is a class that composes the shapes that should be used to view and edit content parts. Drivers live in their own folder called `Drivers`. A basic driver class will contain three methods: a _display_ driver for viewing a content part in the front end, an _editor_ driver for presenting an editor form in the admin dashboard and an _update_ method to handle changes submitted from the editor form.
 
 As the shapes are created in the driver you can also pass data through to a view. Views are discussed in the next section but first we need to wire in the plumbing.
 
@@ -354,9 +354,9 @@ The widget that we are building has no configuration, so all this driver will ne
 
 There aren't any command line scaffolding commands for setting up new drivers so you will need to create it manually:
 
-  1. Make a new `Drivers` folder (`Right click` on the module project in the solution explorer, click `Add`, `New Folder`)
+  1. Make a new `Drivers` folder (_Right click_ on the module project in the solution explorer, click **Add**, **New Folder**)
   
-  1. Add a new class called `FeaturedProductDriver` by right clicking the `Drivers` folder, clicking `Add`, `Class...` and typing `FeaturedProductDriver` for the name (Visual Studio will automatically add the `.cs` on to the end for you) 
+  1. Add a new class called `FeaturedProductDriver` by right clicking the `Drivers` folder, clicking **Add**, **Class...** and typing `FeaturedProductDriver` for the name (Visual Studio will automatically add the `.cs` on to the end for you) 
   
      ![](../Attachments/getting-started-with-modules-part-1/driver-addclass.png)
      
@@ -374,7 +374,7 @@ In the future we will do a lot with the driver class and the way that it builds 
             shapeHelper.Parts_FeaturedProduct());
         }
 
-This says that when displaying the `FeaturedProductPart` return a shape called `Parts_FeaturedProduct`. By default Orchard will look for this shape in  `Views\Parts\FeaturedProduct.cshtml` which is what we will build next.
+This says that when displaying the `FeaturedProductPart` return a shape called `Parts_FeaturedProduct`. By default Orchard will look for this shape in `Views\Parts\FeaturedProduct.cshtml` which is what we will build next.
 
 Your `FeaturedProductDriver.cs` file should now look like this:
 
@@ -396,7 +396,7 @@ Orchard uses Razor template views to display it's shapes. You can supply strongl
 
 For this first widget our needs are simple and we will only be putting plain HTML markup inside the `.cshtml` file:
 
-  1. Add a new folder inside the `Views` folder called `Parts` (`Right click` on the `View` folder in the solution explorer, click `Add`, `New Folder` and type `Parts`).
+  1. Add a new folder inside the `Views` folder called `Parts` (_Right click_ on the `View` folder in the solution explorer, click **Add**, **New Folder** and type `Parts`).
   
   1. Add a new `.cshtml` Razor view within the `Parts` folder called `FeaturedProduct.cshtml`
   
@@ -418,27 +418,27 @@ For this first widget our needs are simple and we will only be putting plain HTM
 ## Placement
 Almost all of the key elements are in place now except for this last one. The configuration inside a driver class tells Orchard *how* to render that content part. Content parts always exist within a larger composite content item. Placement is used to tell Orchard *where* to render these components.
 
-The `placement.info` file goes in the root folder of the module. It is an XML file with a simple structure. You can learn more about the placement.info in [understanding placement.info](Understanding-placement-info) guide.
+The `Placement.info` file goes in the root folder of the module. It is an XML file with a simple structure. You can learn more about the `Placement.info` file in the [understanding placement.info](Understanding-placement-info) guide.
 
-Add the `placement.info` file to your module:
+Add the `Placement.info` file to your module:
 
-  1. `Right click` on the module project in the solution explorer.
+  1. _Right click_ on the module project in the solution explorer.
   
-  1. Choose `Add`, `New Item` to get to the add item screen:
+  1. Choose **Add**, **New Item** to get to the add item screen:
   
      ![](../Attachments/getting-started-with-modules-part-1/placement-addfile.png)
   
-  1. From the templates categories in the left hand side, choose `General`
+  1. From the templates categories in the left hand side, choose **General**
   
-  1. Find `Text File` in the list
+  1. Find **Text File** in the list
   
-  1. Enter `placement.info` in the **Name:** field.
+  1. Enter `Placement.info` in the **Name:** field.
   
-  1. Click `OK`
+  1. Click **OK**
   
 This module has a single shape so we need to set up a `<Place>` for that shape. 
 
-  1. Add this snippet to the empty placement.info file:
+  1. Add this snippet to the empty `Placement.info` file:
 
         <Placement>
           <Place Parts_FeaturedProduct="Content:1"/>
@@ -446,9 +446,9 @@ This module has a single shape so we need to set up a `<Place>` for that shape.
 
 The `Content:1` is the zone and priority of that shape. A shape will have several zones defined for it. Typically these include the header, content, meta and footer but they can have any combination of zones defined. In this case the `Content` is the main content area.
 
-The priority means that it will be near the top of the content zone. In more complicated modules there could be several shapes. Setting different priorities will let you organize their display order when you want them to be in the same zone. For example, if another shape had a place of `Content:0.5` it would go before it, `Content:15` and it would go after it.
+The priority means that it will be near the top of the content zone. In more complicated modules there could be several shapes. Setting different priorities will let you organize their display order when you want them to be in the same zone. For example, if another shape had a place of `Content:0.5` it would go before it, and `Content:15` would go after it.
 
-Theme developers can customize these layout preferences by providing their own placement.info and overriding your initial configuration. This lets theme authors customize your module without having to make changes to the actual code. This means when the module is upgraded to a new version the theme developers changes will not be overwritten.
+Theme developers can customize these layout preferences by providing their own `Placement.info` and overriding your initial configuration. This lets theme authors customize your module without having to make changes to the actual code. This means when the module is upgraded to a new version the theme developers' changes will not be overwritten.
 
 ## Trying the module out in Orchard
 Congratulations, you've made it to the pay off, using the module in Orchard!
@@ -465,13 +465,13 @@ The last few steps will enable the module in Orchard and assign the widget to a 
   
      ![](../Attachments/getting-started-with-modules-part-1/enable-module.png)
   
-     Click `Enable` to activate the plugin:
+     Click **Enable** to activate the plugin:
      
      ![](../Attachments/getting-started-with-modules-part-1/enabled-module.png)
 
-  1. You can now add the Widget to a layer in the site. Click `Widgets` from the navigation menu.
+  1. You can now add the Widget to a layer in the site. Click **Widgets** from the navigation menu.
    
-  1. In the `AsideFirst` section of the Widgets page click the `Add` button:
+  1. In the `AsideFirst` section of the Widgets page click the **Add** button:
    
      ![](../Attachments/getting-started-with-modules-part-1/activate-addtolayer.png)
      
@@ -483,7 +483,7 @@ The last few steps will enable the module in Orchard and assign the widget to a 
   
      ![](../Attachments/getting-started-with-modules-part-1/activate-widgettitle.png)
 
-  1. Click `Save` at the bottom of the page.
+  1. Click **Save** at the bottom of the page.
   
 If you go back to the main site now you will see the module in the site:
 
@@ -498,7 +498,7 @@ You can download a copy of the module so far at this link:
   
 To use it in Orchard simply extract the archive into the modules directory at `.\src\Orchard.Web\Modules\`.
 
-> For Orchard to recognize it the folder name should match the name of the module. Make sure that the folder name is `Orchard.LearnOrchard.FeaturedProduct` and then the modules files are located directly under that. 
+> For Orchard to recognize it, the folder name should match the name of the module. Make sure that the folder name is `Orchard.LearnOrchard.FeaturedProduct` and then the modules files are located directly under that. 
 
 ## Conclusion
 This first guide in the module introduction course has shown the main components of a module.

--- a/docs/Documentation/Getting-Started-with-Modules-Part-2.markdown
+++ b/docs/Documentation/Getting-Started-with-Modules-Part-2.markdown
@@ -33,9 +33,9 @@ If for some reason you don't have these files you can play catch-up by following
 
   1. Download the [completed module source code from part 1](../Attachments/getting-started-with-modules-part-1/Orchard.LearnOrchard.FeaturedProduct-Part1-v1.0.zip).
   
-  1.  Extract the archive into the modules directory at `.\src\Orchard.Web\Modules\`.
+  1.  Extract the archive into the modules directory at `.\src\Orchard.Web\Modules\ `.
   
-  1.  Run Orchard by pressing `Ctrl-F5`, go to the admin dashboard, select Modules from the navigation menu and enable the module.
+  1.  Run Orchard by pressing `Ctrl-F5`, go to the admin dashboard, select **Modules** from the navigation menu and enable the module.
 
 Now we can begin the lesson by starting to build in database functionality to the Featured Product module.
 
@@ -48,9 +48,9 @@ The `ContentPartRecord` class is used by Orchard to store content part data in a
 
 Let's add the class to the module and then start wiring in the `Boolean` `IsOnSale` property:
 
-  1. Locate your FeaturedProduct module in the `Solution Explorer`, `Right click` on the `Models` folder and choose `Add`, `Class...`
+  1. Locate your FeaturedProduct module in the **Solution Explorer**, _Right click_ on the `Models` folder and choose **Add**, **Class...**
   
-  1. In the `Add New Item` dialog enter `FeaturedProductPartRecord` in to the `Name:` field and press `Add`.
+  1. In the **Add New Item** dialog enter `FeaturedProductPartRecord` in to the **Name:** field and press **Add**.
   
   1. Derive the class from `ContentPartRecord`:
   
@@ -82,14 +82,14 @@ You should now end up with a file called `.\Models\FeaturedProductPartRecord.cs`
       }
     }
 
-## Update the ContentPart
+## Update the `ContentPart`
 You now have a class that will provide the interface between your database and your content part (`FeaturedProductPartRecord`).
 
 The first change to the content part will be to let it know about this record class. Then we will add a public property which mirrors the data class and specifies how it will store its data:
 
   1. Open the `ContentPart` file located in `.\Models\FeaturedProductPart.cs`
   
-  1. Add a generic type parameter to the FeaturedProductPart class by changing this:
+  1. Add a generic type parameter to the `FeaturedProductPart` class by changing this:
   
          public class FeaturedProductPart : ContentPart
      
@@ -126,7 +126,7 @@ You should now end up with a `FeaturedProductPart.cs` file that looks like this:
 
 The `Retrieve()` and `Store()` methods come when you inherit from `ContentPart<T>`. 
 
-Under the hood your data is stored in two places. There is the underlying database and something called the infoset.
+Under the hood your data is stored in two places. There is the underlying _database_ and something called the _infoset_.
 
 ## Understanding data storage in Orchard
 Orchard provides an incredibly modular architecture. The way it achieves this is that it breaks everything up into their own little components called content parts. We are busy building one of these content parts right now. Orchard composes these together at run-time to form content types, such as the widget we are working on.
@@ -144,7 +144,7 @@ To minimize these effects a secondary data cache is kept. All of the different c
         Zone="AsideFirst" Name="" CssClasses="" />
     </Data>
 
-So instead of pulling data from three different tables (IdentityPart, CommonPart and WidgetPart) Orchard just selects the single XML block and checks in there. The `Retrieve()` and `Store()` methods automatically keep this data and the individual database tables in sync for you.
+So instead of pulling data from three different tables (`IdentityPart`, `CommonPart` and `WidgetPart`) Orchard just selects the single XML block and checks in there. The `Retrieve()` and `Store()` methods automatically keep this data and the individual database tables in sync for you.
 
 Why not just use the XML infoset all the time? If you need to sort the data or filter it then its actually quicker to do this all within the SQL database server rather than extracting everything and sorting / filtering it after.
 
@@ -187,7 +187,7 @@ We then add our column with a data type `bool` and a name `IsOnSale` which match
 
 > **Bonus Exercise:** Look around in the `Migrations.cs` files located in the other built-in modules for many examples of the things you can do with this class.
 
->  To do this just select the `Search Solution Explorer` textbox at the top of the `Solution Explorer` or press `Ctrl-;`. When it's selected just type `Migrations.cs` in and it will filter out all of the `migrations.cs` files in the solution.
+>  To do this just select the **Search Solution Explorer** textbox at the top of the **Solution Explorer** or press `Ctrl-;`. When it's selected just type `Migrations.cs` in and it will find all of the `Migrations.cs` files in the solution.
 
 You should now end up with a `Migrations.cs` file that looks like this:
 
@@ -234,11 +234,11 @@ For example, you could build an analytics module that listens to the `Loaded` ev
 
 The handler you need in this module is not going to be very complex, but it will implement some plumbing that is necessary to set up the persistence of the part:
 
-  1. In the `Solution Explorer`, right click on the `Orchard.LearnOrchard.FeaturedProduct` project and choose `Add`, `New Folder` and create a new folder called `Handlers`.
+  1. In the **Solution Explorer**, right click on the `Orchard.LearnOrchard.FeaturedProduct` project and choose **Add**, **New Folder** and create a new folder called `Handlers`.
   
-  1. Now right click on the `Handlers` folder and choose `Add`, `Class...`.
+  1. Now right click on the `Handlers` folder and choose **Add**, **Class...**.
   
-  1. In the `Add New Item` dialog enter `FeaturedProductHandler` in to the `Name:` field and press `Add`.
+  1. In the **Add New Item** dialog enter `FeaturedProductHandler` in to the `Name:` field and press **Add**.
   
   1. Derive the class from `ContentHandler`:
   
@@ -273,13 +273,13 @@ You should now end up with a `FeaturedProductHandler.cs` file that looks like th
     }
 
 ## Update the driver to support an editor view
-This time through with the driver it's going to get it's other two core boilerplate methods.
+This time through with the driver it's going to get its other two core boilerplate methods.
 
 The first is a method called `Editor()` which is used to build the shape which will display the edit interface in the admin dashboard. This is designed to be used with a HTTP `GET` request.
 
 The second is another `Editor()` overload which takes the submitted information from the first and attempts to pass that information back into the database. This is designed to be used with a HTTP `POST` request.
 
-  1. Open the `FeaturedProductDriver.cs` class which is in the `.\Drivers\` folder of the module project.
+  1. Open the `FeaturedProductDriver.cs` class which is in the `.\Drivers\ ` folder of the module project.
   
   1. Below the `Display()` method, paste in this block of code:
   
@@ -300,9 +300,9 @@ The second is another `Editor()` overload which takes the submitted information 
         
   1. Add the namespace for `IUpdateModel` using the `Ctrl-.` keyboard shortcut.
 
-As explained above, the first `Editor()` method is for displaying an edit form in the admin dashboard. You can see that it returns a content shape called `Parts_FeaturedProduct_Edit`. We will use this information later on when updating the `placement.info`. 
+As explained above, the first `Editor()` method is for displaying an edit form in the admin dashboard. You can see that it returns a content shape called `Parts_FeaturedProduct_Edit`. We will use this information later on when updating the `Placement.info`. 
 
-The way it does it is by using the provided `shapeHelper` factory to create a new shape for the current content part (our FeaturedProductPart with the `bool IsOnSale` property). This is the same shape factory we used in our `Display()` method the first time around.
+The way it does it is by using the provided `shapeHelper` factory to create a new shape for the current content part (our `FeaturedProductPart` with the `bool IsOnSale` property). This is the same shape factory we used in our `Display()` method the first time around.
 
 For editor views you use the `.EditorTemplate()` method and pass in the configuration values. By default, Orchard places all of its editor views in the `EditorTemplates` folder. Combining this with the `TemplateName` parameter we know that we will be creating a view called `.\Views\EditorTemplates\Parts\FeaturedProduct.cshtml` in the next section.
 
@@ -442,10 +442,10 @@ You should now have a `FeaturedProduct.cshtml` file that looks like this:
     <p>Todays featured product is the Sprocket 9000.</p>
     <p><a href="/sprocket-9000" class="btn-green">Click here to view it</a></p>
 
-## Update the placement.info
+## Update the `Placement.info` file
 Before we run the module to see our updated widget in action we need to make a change to the `placement.info` file. The module should run without errors at this stage but until we set up a `<place>` for the editor template you won't be able to configure the `IsOnSale` variable.
 
-  1. Open the `placement.info` file located in the root folder of the module.
+  1. Open the `Placement.info` file located in the root folder of the module.
   
   1. Within the `<placements>` tag add the following `<place>` tag:
   
@@ -455,11 +455,11 @@ Before we run the module to see our updated widget in action we need to make a c
 
 The name of the place that we are targeting `Parts_FeaturedProduct_Edit` was defined in the driver class when we configured it in the `EditorTemplate()` shape factory method. The shape will be injected into the local zone named "content" with a weight of 7.5. In this case the weight of 7.5 will move it down to the bottom of the form.
 
-> When developing your modules it is common to forget this last stage. While you might not always be able to remember to update the `placement.info` before you run, you should take a moment to remember the solution.
+> When developing your modules it is common to forget this last stage. While you might not always be able to remember to update the `Placement.info` before you run, you should take a moment to remember the solution.
 
-> Whenever the shape isn't displayed where it was expected, think `placement.info` first.
+> Whenever the shape isn't displayed where it was expected, think of `Placement.info` first.
 
-You should now have a `placement.info` file that looks like this:
+You should now have a `Placement.info` file that looks like this:
 
     <Placement>
       <Place Parts_FeaturedProduct="Content:1"/>
@@ -469,23 +469,23 @@ You should now have a `placement.info` file that looks like this:
 ## Trying the module out in Orchard
 Great! You have completed another stage of the development. Now its time to load the website up in the browser and play with the new feature you just built.
 
-  1. Within Visual Studio, press `Ctrl-F5` on your keyboard to start the website without debugging enabled (its quicker and you can attach the debugger later if you need it).
+  1. Within Visual Studio, press `Ctrl-F5` on your keyboard to start the website without debugging enabled (it's quicker and you can attach the debugger later if you need it).
   
   1. Navigate to the admin dashboard.
   
-  1. Click `Widgets` in the side menu.
+  1. Click **Widgets** in the side menu.
   
-  1. If you follow the guide correctly in part 1, you should see your `Featured Product Widget` in the list under `AsideFirst`. Click on the word `Featured Product` (this may vary depending the title you entered when you set the widget up):
+  1. If you follow the guide correctly in part 1, you should see your **Featured Product Widget** in the list under `AsideFirst`. Click on the word **Featured Product** (this may vary depending the title you entered when you set the widget up):
   
     ![](../Attachments/getting-started-with-modules-part-2/testing1-editwidget.png)
     
-  1. The `Edit Widget` page will be displayed. Scroll down to the bottom to find the setting we added:
+  1. The **Edit Widget** page will be displayed. Scroll down to the bottom to find the setting we added:
   
     ![](../Attachments/getting-started-with-modules-part-2/testing1-configure.png)
   
     Tick the checkbox. 
     
-  1. Click `Save`.
+  1. Click **Save**.
   
   1. Navigate back to the homepage of the website by clicking on the site title in the top corner of the admin dashboard:
   
@@ -502,15 +502,15 @@ You can download a copy of the module so far at this link:
 
   * [Download Orchard.LearnOrchard.FeaturedProduct-Part2-v1.0.zip](../Attachments/getting-started-with-modules-part-2/Orchard.LearnOrchard.FeaturedProduct-Part2-v1.0.zip)
   
-To use it in Orchard simply extract the archive into the modules directory at `.\src\Orchard.Web\Modules\`. If you already have the module installed from a previous part then delete that folder first.
+To use it in Orchard simply extract the archive into the modules directory at `.\src\Orchard.Web\Modules\ `. If you already have the module installed from a previous part then delete that folder first.
 
-> For Orchard to recognize it the folder name should match the name of the module. Make sure that the folder name is `Orchard.LearnOrchard.FeaturedProduct` and then the modules files are located directly under that.
+> For Orchard to recognize it, the folder name should match the name of the module. Make sure that the folder name is `Orchard.LearnOrchard.FeaturedProduct` and then the modules files are located directly under that.
 
 ## Conclusion
 This part of the course has expanded your knowledge to touch on some of the data storage and content management features in Orchard. 
 
 You have added in the common module development classes that we didn't cover in the first part. You've experienced using the data migrations to incrementally update your data. You've also seen the basics of creating an admin interface and using it to update the configuration settings of a widget.
 
-You can now see the core process of adding a variable to your module and then implementing it, working successively up the layers to surface it in the admin dashboard and the front-end view.  
+You can now see the core process of adding a variable to your module and then implementing it, working successively up the layers to surface it in the admin dashboard and the front-end view.
 
 In the next part of the getting started with modules course we will look at [working with content items at the code level](Getting-Started-with-Modules-Part-3).

--- a/docs/Documentation/Getting-Started-with-Modules-Part-3.markdown
+++ b/docs/Documentation/Getting-Started-with-Modules-Part-3.markdown
@@ -14,7 +14,7 @@ At the moment the widget is displayed site-wide with a big green "Click here to 
 
 In the previous part we added a configurable item to the widget. The widget read that setting in and updated itself. The same code is run no matter where you embed the widget. 
 
-This time, we will expand the widget so that it is aware of it's surroundings. When the page loads and the widget is asked to display, it will inspect the page as a whole, figure out what type of page it is on and then, if applicable, drill down to see what specific product page it's on. 
+This time, we will expand the widget so that it is aware of its surroundings. When the page loads and the widget is asked to display, it will inspect the page as a whole, figure out what type of page it is on and then, if applicable, drill down to see what specific product page it's on. 
 
 This information will then be passed through to the view so that we can change the display on the fly. 
 
@@ -25,38 +25,38 @@ The admin dashboard is quite powerful. If you have been using Orchard for long y
 
 This section allows you to combine pre-existing content parts together to form a custom content type that can be displayed in your site. 
 
-It also has a section called `Fields`. When there isn't a content part that quite fits your needs you can turn to the `Fields` to add extra pieces of data to the content type on the fly.
+It also has a section called **Fields**. When there isn't a content part that quite fits your needs you can turn to the **Fields** to add extra pieces of data to the content type on the fly.
 
 We are going to quickly build a `Product` content type which has some of the common core content parts; a title, a URL, a menu entry and some body text. We will also add in single text field called `Product Id` to detect which particular product is being viewed:
 
   1. Navigate to the admin dashboard of your site.
   
-  1. Click `Content Definition` in the menu down the side.
+  1. Click **Content Definition** in the menu down the side.
   
-  1. Click `Create new type`.
+  1. Click **Create new type**.
   
   1. Enter `Product` for the `Display Name`. This should automatically fill out the `Content Type Id` field for you. Make sure the `Content Type Id` is also set to `Product`:
   
     ![](../Attachments/getting-started-with-modules-part-3/democontent-newtype.png)
   
-  1. Click `Create`.
+  1. Click **Create**.
   
-  1. In the `Add Parts to "Product"` section tick the following parts:
+  1. In the **Add Parts to "Product"** section tick the following parts:
   
        * Autoroute
        * Body
        * Menu
        * Title
 
-  1. Click `Save`. You will be taken to the `Edit Content Type` page and you should see several messages from the Orchard notifier system:
+  1. Click **Save**. You will be taken to the **Edit Content Type** page and you should see several messages from the Orchard notifier system:
   
     ![](../Attachments/getting-started-with-modules-part-3/democontent-partsadded.png)
   
-  1. Scroll down to the `Fields` section and then click the `Add Field` button:
+  1. Scroll down to the **Fields** section and then click the **Add Field** button:
   
     ![](../Attachments/getting-started-with-modules-part-3/democontent-addfield.png)
     
-  1. On the `Add New Field To "Product"` page fill the form out like this:
+  1. On the **Add New Field To "Product"** page fill the form out like this:
   
       * Display Name: `Product Id`
       * Technical Name: `ProductId`
@@ -64,15 +64,15 @@ We are going to quickly build a `Product` content type which has some of the com
 
   ![](../Attachments/getting-started-with-modules-part-3/democontent-addnewfield.png) 
      
-  1. Click `Save`.
+  1. Click **Save**.
   
-  1. The main `Edit Content Type` page will reopen. Just for completeness lets configure the field so that it is flagged as required. If you scroll to the `Fields` section you will see your new field is now listed. The small `>` will expand out to show configuration properties for that field:
+  1. The main **Edit Content Type** page will reopen. Just for completeness lets configure the field so that it is flagged as required. If you scroll to the **Fields** section you will see your new field is now listed. The small `>` will expand out to show configuration properties for that field:
   
      ![](../Attachments/getting-started-with-modules-part-3/democontent-configurefield.png)
      
      Click the `>` to expand the field configuration pane.
 
-  1. Tick the `Required` check box:
+  1. Tick the **Required** check box:
   
      ![](../Attachments/getting-started-with-modules-part-3/democontent-required.png)
      
@@ -86,7 +86,7 @@ We are going to quickly build a `Product` content type which has some of the com
     
     In the Pattern field enter the pattern `^[A-Z0-9]+$`.
     
-  1. Click `Save`.
+  1. Click **Save**.
 
 In the next section we will create a demo product using this new content type.
 
@@ -104,11 +104,11 @@ For this to work we need to create a dummy product that will act as the featured
 
   1. Navigate to the admin dashboard of your site.
   
-  1. In the `New` section of the menu click `Product`:
+  1. In the **New** section of the menu click **Product**:
   
      ![](../Attachments/getting-started-with-modules-part-3/demoproduct-new.png)
 
-  1. Set the `Title` of the page to `Sprocket 9000`.
+  1. Set the `Title` of the page to "Sprocket 9000".
   
   1. Leave the `Permalink` blank.
   
@@ -129,23 +129,23 @@ For this to work we need to create a dummy product that will act as the featured
   
     Enter `SPROCKET9000` into the `Product Id`.
     
-  1. Tick the `Show on a menu` checkbox.
+  1. Tick the **Show on a menu** checkbox.
   
-  1. Leave the menu selection on `Main Menu`.
+  1. Leave the menu selection on **Main Menu**.
   
-  1. In the `Menu text` enter the product name, `Sprocket 9000`.
+  1. In the **Menu text** enter the product name, "Sprocket 9000".
   
-  1. Click `Publish Now`.
+  1. Click **Publish Now**.
   
 The page will reload after Orchard has created the new content item in the background. You will see a green message saying "Your Page has been created":
 
 ![](../Attachments/getting-started-with-modules-part-3/demoproduct-created.png)
   
-If you navigate back to the front-end of the website you should see a new menu item called `Sprocket 9000`. Clicking it will take you to the demo page you just created:
+If you navigate back to the front-end of the website you should see a new menu item called **Sprocket 9000**. Clicking it will take you to the demo page you just created:
 
 ![](../Attachments/getting-started-with-modules-part-3/demoproduct-page.png)
 
-If the menu option doesn't appear on the page you probably clicked `Save` instead of `Publish`. When we created the content type is defaults to being marked as draftable. This means that you can save a copy in the system before it's made available publically. Until you click the `Publish Now` button it won't show on the website.
+If the menu option doesn't appear on the page you probably clicked **Save** instead of **Publish**. When we created the content type is defaults to being marked as _draftable_. This means that you can save a copy in the system before it's made available publicly. Until you click the **Publish Now** button it won't show on the website.
 
 That's all the preparation we need to do before we can dive back into the code. 
 
@@ -198,7 +198,7 @@ An alternative solution to expanding out this `Display()` method would have been
           () => shapeHelper.Parts_FeaturedProduct());
     }
 
-What's the difference and why is this a bad idea? The `Display()` method gets called  to prepare the shapes each time a visitor requests a page. With the modularity of the Orchard code you might still end up having something else on the page influencing it's display so that the shape doesn't make it to the final output.
+What's the difference and why is this a bad idea? The `Display()` method gets called to prepare the shapes each time a visitor requests a page. With the modularity of the Orchard code you might still end up having something else on the page influencing its display so that the shape doesn't make it to the final output.
 
 When the setup code is passed within the lambda it doesn't get run until it's actually needed. This means that if you need to do some "expensive" setup code you don't want to run it unless you're sure it's going to be used. In this context expensive means heavy resource usage (it could require complicated database calls or data crunching) or time consuming (you might rely on calling a 3rd party web service to get some information).
 
@@ -206,7 +206,7 @@ You don't want to waste your resources and slow down the page being displayed by
 
 Let's implement what we have discussed so far:  
 
-  1. Open up the `FeaturedProductDriver.cs` file located in the `.\Drivers\` folder.
+  1. Open up the `FeaturedProductDriver.cs` file located in the `.\Drivers\ ` folder.
   
   1. Replace the `Display()` method with the following:
   
@@ -243,7 +243,7 @@ We could add a public property to the driver which looked like this:
 But where do all of these supporting classes like `_aliasService` and `_contentManager` come from?
 
 ## Dependency injection in Orchard
-The modular design of Orchard means that each feature of Orchard tries to be as independent as it can. This means that when the Widget is building it's shape it doesn't automatically know about the wider context of the page being requested. It is a specialized unit of code which completes it's task as efficiently and simply as possible.
+The modular design of Orchard means that each feature of Orchard tries to be as independent as it can. This means that when the Widget is building its shape it doesn't automatically know about the wider context of the page being requested. It is a specialized unit of code which completes its task as efficiently and simply as possible.
 
 When it's required, the module can request access to parts of the larger Orchard system through the use of Orchard's service classes.
 
@@ -262,7 +262,7 @@ So if you wanted a copy of the content manager then you would request `IContentM
 
 The standard process for incorporating a new service into the class is as follows (you don't need to do this now):
 
-  1. Create a new private, read only variable to hold the injected class. It should start with an underscore like `_contentManager`.
+  1. Create a new private, read-only variable to hold the injected class. It should start with an underscore like `_contentManager`.
    
   1. Update the default constructor to include the service as a parameter.
   
@@ -275,7 +275,7 @@ Based on the service requirements in our demo implementation above of the `Curre
 
 Taking what we have learned about dependency injection and knowing our service requirements we can now implement the next stage of the `FeaturedProductDriver` class:
 
-  1. Open up the `FeaturedProductDriver.cs` file located in the `.\Drivers\` folder.
+  1. Open up the `FeaturedProductDriver.cs` file located in the `.\Drivers\ ` folder.
   
   1. Add the following properties to the top of the `FeaturedProductDriver` class:
   
@@ -283,21 +283,21 @@ Taking what we have learned about dependency injection and knowing our service r
         private readonly IWorkContextAccessor _workContextAccessor;
         private readonly IAliasService _aliasService;
 
-    `IAliasService` will need it's namespace but when you try to add it via `Ctrl-.` you will see Visual Studio doesn't know where to find it.
+    `IAliasService` will need its namespace but when you try to add it via `Ctrl-.` you will see Visual Studio doesn't know where to find it.
   
      We need to add a reference and update the dependencies of our module.
-     
-  1. `Right click` on the `References` entry in the module's project within the `Solution Explorer` window and choose `Add Reference...`.
+
+  1. _Right click_ on the **References** entry in the module's project within the **Solution Explorer** window and choose **Add Reference...**.
   
-  1. Click the `Projects` tab on the left. `Orchard.Alias` should already be visible. `Hover` your mouse over it and a checkbox will appear. Click the checkbox for `Orchard.Alias`. Click `OK`.
+  1. Click the **Projects** tab on the left. `Orchard.Alias` should already be visible. _Hover_ your mouse over it and a checkbox will appear. Click the checkbox for `Orchard.Alias`. Click **OK**.
   
      ![](../Attachments/getting-started-with-modules-part-3/orchardalias-ref.png)
      
   1. Now we have to update our dependencies straight away so they don't get forgotten. Open up the `Module.txt` file located in the project root.
   
-  1. The last line of the file should contain the `Orchard.Widgets` dependency that we created in part one. This field will take a comma separated list detailing  each dependency a modules has.
+  1. The last line of the file should contain the `Orchard.Widgets` dependency that we created in part one. This field will take a comma separated list detailing each dependency a modules has.
   
-    Update the line to add `Orchard.Alias`, ensuring that the line keeps it's indentation, so that the line now looks like this:
+    Update the line to add `Orchard.Alias`, ensuring that the line keeps its indentation, so that the line now looks like this:
     
                 Dependencies: Orchard.Widgets, Orchard.Alias
 
@@ -417,7 +417,7 @@ We will do this by declaring `bool isOnFeaturedProductPage = false;` at the top 
 
 Modify the first `Display()` method by following these steps:
 
-  1. Open up the `FeaturedProductDriver.cs` file located in the `.\Drivers\` folder.
+  1. Open up the `FeaturedProductDriver.cs` file located in the `.\Drivers\ ` folder.
   
   1. Locate the `Display()` method and replace it with the following:
   
@@ -436,17 +436,17 @@ This has laid the groundwork for us. The next piece of code will detect the cont
 ## Detecting the content type
 The `CurrentContent` property that we implemented doesn't exactly return the current content item, it returns an `IContent`. This contains a property called `ContentItem` which then gives us access to everything related to the current content item.
 
-You can explore the `ContentItem` class by navigating around the IntelliSense, or by navigating to the class itself with `F12`. There are lots of interesting properties to use.
+You can explore the `ContentItem` class by navigating around using IntelliSense, or by navigating to the class itself with `F12`. There are lots of interesting properties to use.
 
 The content type is stored as a string inside a `ContentTypeDefinition` property called `TypeDefinition`. You can get to it using this notation:
 
     var itemTypeName = CurrentContent.ContentItem.TypeDefinition.Name;
     
-The `itemTypeName` variable will then contain a string version of the content type. The `Product` content type was created via the admin dashboard. This means that there isn't a concrete class for us to use in a `typeof(T).Name` call so we will have to work with the string `"Product"` when we're checking the type of the current content item.
+The `itemTypeName` variable will then contain a string version of the content type. The `Product` content type was created via the admin dashboard. This means that there isn't a concrete class for us to use in a `typeof(T).Name` call so we will have to work with the string "Product" when we're checking the type of the current content item.
 
 Putting the code together is just a case of a standard .NET string comparison:
 
-  1. Open up the `FeaturedProductDriver.cs` file located in the `.\Drivers\` folder.
+  1. Open up the `FeaturedProductDriver.cs` file located in the `.\Drivers\ ` folder.
   
   1. Locate the `Display()` method and replace it with the following:
   
@@ -481,19 +481,19 @@ We are going to cover the two important things you need to learn about fields so
 
 The first important thing to understand is: `Fields` are *always* in a `ContentPart`.
 
-To be fair, it looked like you had just created the field loose in the content type:
+To be fair, it looked like you had just created the field outside of the content type:
 
 ![](../Attachments/getting-started-with-modules-part-3/fields-hiddencontentpart.png)
 
-But in truth, Orchard created an invisible ContentPart for you and attached those fields to that. The name of that content part is the name of the content type. So for our `Product` content type, the content part would be `Product`. For a `HtmlWidget` it would be `HtmlWidget`, if you added a field to the `Page` you would access it with `Page`.
+But in truth, Orchard created an invisible `ContentPart` for you and attached those fields to that. The name of that content part is the name of the content type. So for our `Product` content type, the content part would be `Product`. For a `HtmlWidget` it would be `HtmlWidget`, if you added a field to the `Page` you would access it with `Page`.
 
 So the way to access our `ProductId` field which is on the `ContentType` of `Product` we would write:
 
     var productId = CurrentContent.ContentItem.Product.ProductId.Value;
     
-Where did the `.Value` come from? Well, your field is not just a simple string. You defined it as a `"Text Field"` when you filled out the form. This maps to the `Orchard.Fields.Fields.InputField` class and you can access it's data through the `.Value` property.
+Where did the `.Value` come from? Well, your field is not just a simple string. You defined it as a `"Text Field"` when you filled out the form. This maps to the `Orchard.Fields.Fields.InputField` class and you can access its data through the `.Value` property.
 
-> As you build up your skills as an Orchard module developer one of the important ones will be digging through the code to discover this sort of thing for yourself. As I was writing this I didn't know what the class was called. To find it out I put a breakpoint on the line of code, started a debug session and inspected the field to see what class it was and how to get at it's data.
+> As you build up your skills as an Orchard module developer one of the important ones will be digging through the code to discover this sort of thing for yourself. As I was writing this I didn't know what the class was called. To find it out I put a breakpoint on the line of code, started a debug session and inspected the field to see what class it was and how to get at its data.
 
 > This is a useful skill to have in your repertoire when working with Orchard but in this case you also have a useful resource that has been put together by Sebastien Ros. He has created an [Orchard Cheatsheet](http://sebastienros.github.io/CheatSheet/) which covers common properties that you might want to access on each of the built-in Orchard content fields.
 
@@ -506,7 +506,7 @@ This means you don't get IntelliSense for dynamic properties. It also means that
 
 Once you have the product id in a string it's just a case of comparing it against the known value and setting `isOnFeaturedProductPage = true` if it's a match:
 
-  1. Open up the `FeaturedProductDriver.cs` file located in the `.\Drivers\` folder.
+  1. Open up the `FeaturedProductDriver.cs` file located in the `.\Drivers\ ` folder.
   
   1. Locate the `Display()` method and replace it with the following:
   
@@ -664,7 +664,7 @@ This is the part where it all pays off. If you run Orchard in the browser you wi
   
     ![](../Attachments/getting-started-with-modules-part-3/testing-homepage.png)
     
-  1. Click on the `Sprocket 9000` menu item to go to your product page. You should see a purple notification box instead of a link:
+  1. Click on the **Sprocket 9000** menu item to go to your product page. You should see a purple notification box instead of a link:
   
     ![](../Attachments/getting-started-with-modules-part-3/testing-sprocket.png)
     
@@ -679,7 +679,7 @@ You can download a copy of the module so far at this link:
 
   * [Download Orchard.LearnOrchard.FeaturedProduct-Part3-v1.0.zip](../Attachments/getting-started-with-modules-part-3/Orchard.LearnOrchard.FeaturedProduct-Part3-v1.0.zip)
   
-To use it in Orchard simply extract the archive into the modules directory at `.\src\Orchard.Web\Modules\`. If you already have the module installed from a previous part then delete that folder first.
+To use it in Orchard simply extract the archive into the modules directory at `.\src\Orchard.Web\Modules\ `. If you already have the module installed from a previous part then delete that folder first.
 
 > For Orchard to recognize it the folder name should match the name of the module. Make sure that the folder name is `Orchard.LearnOrchard.FeaturedProduct` and then the modules files are located directly under that.
 

--- a/docs/Documentation/Getting-Started-with-Modules-Part-4.markdown
+++ b/docs/Documentation/Getting-Started-with-Modules-Part-4.markdown
@@ -15,9 +15,9 @@ In fact, the only reason these weren't covered earlier was because they aren't e
 The topics in this article will help you add polish to your module and if you're going to release them to the public it will mean the difference between a beginners module and a professional module.
 
 ## Customize the manifest file
-Starting with an easy one, the `module.txt` is a text file you will find in the root of your module folder. We have already looked at this file briefly in this course each time we have added dependencies. When Orchard is scanning the folders looking for modules to load it will parse this file to get information about it.
+Starting with an easy one, the `Module.txt` is a text file you will find in the root of your module folder. We have already looked at this file briefly in this course each time we have added dependencies. When Orchard is scanning the folders looking for modules to load it will parse this file to get information about it.
 
-The `module.txt` is a manifest file. Technically, the document is in YAML format. If you open it now you will see the following:
+The `Module.txt` is a manifest file. Technically, the document is in YAML format. If you open it now you will see the following:
 
     Name: Orchard.LearnOrchard.FeaturedProduct
     AntiForgery: enabled
@@ -40,7 +40,7 @@ The file format is quite straightforward. The fields mean what you would expect 
 
 `Version` is the version of the module.
 
-`OrchardVersion` is the version of Orchard that this module was written against.
+`OrchardVersion` is the version of Orchard that this module was tested against.
 
 `Features` is the only complicated one. We didn't look at it in this course, but you can include several features within a single module. This means you can enable or disable individual parts of the module. The description field and features section work together and can be displayed in several different formats. 
 
@@ -48,16 +48,16 @@ For a detailed explanation of the `Features` section and the other fields [read 
 
 Time to make some changes:
 
-  1. Open `module.txt`.
+  1. Open `Module.txt`.
   
-  1. Edit the `module.txt` to your liking while staying [within the spec](Manifest-files). Go ahead and put your name and details into it. It feels good to see your name in lights!
+  1. Edit the `Module.txt` to your liking while staying [within the spec](Manifest-files). Go ahead and put your name and details into it. It feels good to see your name in lights!
   
   1. Save the file.
   
-You will probably need to restart the development server before Orchard picks up the changes you've made to your `module.txt`.
+You will probably need to restart the development server before Orchard picks up the changes you've made to your `Module.txt`.
 
 ## Categorize your module
-While we are working with the manifest file, there is one field which is very useful but not included by default in the `module.txt`. The field is called `Category:`.
+While we are working with the manifest file, there is one field which is very useful but not included by default in the `Module.txt`. The field is called `Category:`.
 
 If you omit this field then the module defaults to the `Uncategorized` grouping:
 
@@ -69,7 +69,7 @@ It's better to group your module with other modules where possible so that users
 
 In this case we will make our own category, "Learn Orchard", which is the category used for all demo modules on this site:
 
-  1. Open `module.txt`.
+  1. Open `Module.txt`.
   
   1. Add the following line to the file:
   
@@ -79,7 +79,7 @@ In this case we will make our own category, "Learn Orchard", which is the catego
      
   1. Save the file.
   
-You will probably need to restart the development server before Orchard picks up the changes you've made to your `module.txt`.
+You will probably need to restart the development server before Orchard picks up the changes you've made to your `Module.txt`.
 
 ## Localize all of your text
 Orchard has great support for writing global aware, localized websites. Administrators can add cultures to their site for a wide variety of different languages.
@@ -114,7 +114,7 @@ The correct way to format this would be:
 
 > `<p>@T("You have {0} credits left.", @Model.SmsCredits)</p>`
 
-Let's update the front end view so that it follows the correct localized development best practices:
+Let's update the front-end view so that it follows the correct localized development best practices:
 
   1. Open `.\Views\Parts\FeaturedProduct.cshtml`
   
@@ -164,15 +164,15 @@ However, just putting the styles into an external file is not the whole story wi
 
 The quick fix for this is to move the CSS into a `.css` file and then use `Script.Require("filename.css")` to include it:
 
-  1. In the Solution Explorer, `right click` on the `Styles` folder within the module.
+  1. In the Solution Explorer, _right click_ on the `Styles` folder within the module.
   
-  1. Choose `Add`, `New Item...` from the context menu.
+  1. Choose **Add**, **New Item...** from the context menu.
   
-  1. Select `Visual C#` then `Web` from the categories down the left hand side.
+  1. Select **Visual C#** then **Web** from the categories down the left hand side.
   
-  1. Find `Style Sheet` in the list and give it a `Name:` of `FeaturedProduct.css`.
+  1. Find **Style Sheet** in the list and give it a **Name:** of `FeaturedProduct.css`.
   
-  1. Click `Add`.
+  1. Click **Add**.
   
   1. Open `.\Views\Parts\FeaturedProduct.cshtml`.
   
@@ -194,7 +194,7 @@ I have used the word resources so far when describing this feature. This is beca
 
 Each resource is assigned a plain text name. This can then be used in the view and it can also be used if another resource needs to depend on it.
 
-This class is normally found in the `ResourceManifest.cs` file in the root of your module folder but as long as your class implements the `IResourceManifestProvider` interface then Orchard will pick it up.
+This class is normally found in the `ResourceManifest.cs` file in the root of your module folder but as long as your class implements the `IResourceManifestProvider` interface, Orchard will pick it up.
 
 The example code below is a shortened version of the Orchard.Layouts `ResourceManifest.cs` file:
 
@@ -216,7 +216,7 @@ The example code below is a shortened version of the Orchard.Layouts `ResourceMa
 
 You can see that a few of the features of the resource manifest are being used here. The first script, called `Layouts.Lib` uses `SetUrl()` to set up minified (live) and unminified (debug) filenames for the resource. 
 
-It also sets a dependency on a resource called `jQuery`. This is a common feature that you will see throughout many Orchard modules. The `jQuery` resource comes from the `Orchard.jQuery` module. If you looked in the `Orchard.Layouts` `module.txt` then you would find that it specifies a dependency on the `Orchard.jQuery` module.
+It also sets a dependency on a resource called `jQuery`. This is a common feature that you will see throughout many Orchard modules. The `jQuery` resource comes from the `Orchard.jQuery` module. If you looked in the `Orchard.Layouts` `Module.txt` then you would find that it specifies a dependency on the `Orchard.jQuery` module.
 
 This kind of external dependency shows off some more of the resource manager features:
 
@@ -236,11 +236,11 @@ The second `DefineScript` in the example above is included just to show that you
 
 Now that its clear what service the resource manifest provides, let's upgrade the module to use this feature of Orchard:
 
-  1. In the Solution Explorer, `right click` on the module's project name.
+  1. In the Solution Explorer, _right click_ on the module's project name.
  
-  1. Select `Add`, `New Item...` and add a class called `ResourceManifest.cs`.
+  1. Select **Add**, **New Item...** and add a class called `ResourceManifest.cs`.
  
-  1. Add the `IResourceManifestProvider` interface to the `ResourceManfiest` class:
+  1. Add the `IResourceManifestProvider` interface to the `ResourceManifest` class:
  
         public class ResourceManifest : IResourceManifestProvider {
         }
@@ -251,11 +251,11 @@ Now that its clear what service the resource manifest provides, let's upgrade th
   
       ![](../Attachments/getting-started-with-modules-part-4/resourcemanifest-interface.png)
 
-     Use the `Ctrl-.` technique a second time to implement the interface. Choose the first option, `Implement interface`.
+     Use the `Ctrl-.` technique a second time to implement the interface. Choose the first option, **Implement interface**.
      
   1. Remove the `throw new NotImplementedException();` line of code.
   
-  1. In it's space add in the following code:
+  1. In its place add in the following code:
   
         var manifest = builder.Add();
         manifest.DefineStyle("FeaturedProduct").SetUrl("FeaturedProduct.css");
@@ -274,7 +274,7 @@ Now that its clear what service the resource manifest provides, let's upgrade th
   
     Don't forget that the resource doesn't need the `.css` extension on the end.
     
-If you run the module in Orchard now then it will look the same as it did before. While this is a simplistic application of a best practice, I think that from the explanation of it you will see how valuable it will be in more complex modules.
+If you run the module in Orchard now, it will look the same as it did before. While this is a simplistic application of a best practice, I think that from the explanation of it you will see how valuable it will be in more complex modules.
 
 Orchard also has an assets pipeline feature. This feature can help build your resources into the final files to be included by Orchard in the resource manifest. For example, you might want to combine the scripts into a single file or minify your style sheets. If you look in your project you will see a file called `Assets.json` which drives this feature. 
 
@@ -337,7 +337,7 @@ The modifications we made are also tied directly to that driver class. It's enti
 
 The `Orchard.Layouts` module (which is used to manage the contents of pages within Orchard) has the concept of building `Elements`. They are like widgets that you can place on to the layout `Canvas`. If you wrote a custom element for this module then it would need to duplicate the code we wrote in widget driver class. This code should live in a central location.
 
-We have already used a built-in version of the solution to this problem; the Orchard services, such as `IContentManager`. These services are used throughout Orchard so that they can share their functionality. Each of the services implements `IDependency` to share this access.
+We have already used a built-in version of the solution to this problem: the Orchard services, such as `IContentManager`. These services are used throughout Orchard so that they can share their functionality. Each of the services implements `IDependency` to share this access.
 
 In exactly the same way that we used dependency injection to request access to various Orchard services, we can write our own `IDependency` and let the driver ask for this.
 
@@ -351,13 +351,13 @@ In our case there will be only one concrete class so it will be a simple decisio
 
 Let's upgrade the module to use our own service:
 
-  1. In the Solution Explorer, `right click` on the module's project name.
+  1. In the Solution Explorer, _right click_ on the module's project name.
  
-  1. Select `Add`, `New Folder` and name it `Services`
+  1. Select **Add**, **New Folder** and name it `Services`
   
-  1. `Right click` the `Services` folder, select `Add`, `New Item...`.
+  1. _Right click_ the `Services` folder, select **Add**, **New Item...**.
   
-  1. Select the `Interface` item template, name it `IFeaturedProductService` and click `Add`
+  1. Select the `Interface` item template, name it `IFeaturedProductService` and click **Add**
   
   1. The interface should be public so add that keyword to the start of the interface declaration. It should also implement the `IDependency` interface:
   
@@ -377,7 +377,7 @@ Let's upgrade the module to use our own service:
   
   1. Implement its interface using the `Ctrl-.` technique.
   
-  1. Now its time to start moving the code over. Open up the `FeaturedProductDriver.cs` file that's in the `.\Drivers\` folder. Review the code and start thinking about what could be moved out into the service class.
+  1. Now its time to start moving the code over. Open up the `FeaturedProductDriver.cs` file that's in the `.\Drivers\ ` folder. Review the code and start thinking about what could be moved out into the service class.
   
   1. The `CurrentContent` property is only used for calculating the `IsOnFeaturedProductPage` value. The three private variables which hold references to Orchard services are only used by the `CurrentContent` property. This means everything from the start of the class through to the end of the constructor can be moved over.
   
@@ -649,20 +649,20 @@ Your `Migrations.cs` file should now look like this:
     }
 
 
-If you load the Orchard site up in the web browser then the data migration will automatically run. You can see the updated description in the `Content Definitions` page:
+If you load the Orchard site up in the web browser then the data migration will automatically run. You can see the updated description in the **Content Definitions** page:
 
   1. Within Visual Studio, press `Ctrl-F5` to load up the dev server.
   
-  1. Navigate to the admin dashboard and click the `Content Definition` menu option.
+  1. Navigate to the admin dashboard and click the **Content Definition** menu option.
   
-  1. Click the `Content Parts` tab along the top of the page.
+  1. Click the **Content Parts** tab along the top of the page.
   
-  1. Scroll down to the `Featured Product` entry. It will now have a description:
+  1. Scroll down to the **Featured Product** entry. It will now have a description:
   
      ![](../Attachments/getting-started-with-modules-part-4/contentpart-withdescriptionadded.png)
 
 ## Roll your data migrations up into Create()
-Now our `Migrations` class contains a `Create()` and two `UpdateFromN()` methods. As time goes on it will get more added. 
+Now our `Migrations` class contains a `Create()` and two `UpdateFromN()` methods. As time goes on, more will be added. 
 
 We may have some updates which revert earlier mistakes or remove features that aren't needed. There is no point in making a new user that's installing the module for the first time to go through all of these steps if they are no longer needed for the final product.
 
@@ -797,7 +797,7 @@ You can download a copy of the module so far at this link:
 
   * [Download Orchard.LearnOrchard.FeaturedProduct-Part4-v1.0.zip](../Attachments/getting-started-with-modules-part-4/Orchard.LearnOrchard.FeaturedProduct-Part4-v1.0.zip)
   
-To use it in Orchard simply extract the archive into the modules directory at `.\src\Orchard.Web\Modules\`. If you already have the module installed from a previous part then delete that folder first.
+To use it in Orchard simply extract the archive into the modules directory at `.\src\Orchard.Web\Modules\ `. If you already have the module installed from a previous part then delete that folder first.
 
 > For Orchard to recognize it the folder name should match the name of the module. Make sure that the folder name is `Orchard.LearnOrchard.FeaturedProduct` and then the modules files are located directly under that.
 
@@ -805,17 +805,17 @@ To use it in Orchard simply extract the archive into the modules directory at `.
 In this course we have looked at many of the core components that make up a module. These topics included:
 
   * Command-line scaffolding
-  * Module.txt manifest
-  * ContentPart
-  * ContentPartRecord
-  * Widget
+  * `Module.txt` manifest
+  * `ContentPart`
+  * `ContentPartRecord`
+  * `Widget`
   * Data migration
   * Dependency injection
   * Handler
   * Driver
   * Editor view
   * Front-end view
-  * Placement.info
+  * `Placement.info`
   * Content types via the admin dashboard
   * Fields 
   * Localization
@@ -828,7 +828,7 @@ This should have given you a solid grounding for extending Orchard via code. Wit
 
 > **Bonus Exercise:** Using the skills you have now learned, research implement the following:
 
-> 1. Add a Content Picker Field to the `FeaturedProductWidget` part so that you can  select a `Product` to be featured.
+> 1. Add a Content Picker Field to the `FeaturedProductWidget` part so that you can select a `Product` to be featured.
 
 > 1. Implement the code so that the widget will work with the selected `Product` rather than using the hard-coded information we supplied throughout this course. 
 

--- a/docs/Documentation/Getting-Started-with-Modules.markdown
+++ b/docs/Documentation/Getting-Started-with-Modules.markdown
@@ -16,6 +16,6 @@ It will teach you some of the basic components of module development and also en
   
   - **[Getting Started with Modules - Part 4](Getting-Started-with-Modules-Part-4) - Best Practices**
   
-    The final installment reviews the completed widget and brings to light loose-ends. You take a tour back through the code, applying development best-practices along the way.
+    The final installment reviews the completed widget and brings to light loose ends. You take a tour back through the code, applying development best-practices along the way.
 
 When you have completed this course you will have a solid grounding in extending Orchard via code. With this knowledge you will be able to build your own simple modules. You will also understand the concepts underpinning the documentation found elsewhere in this site and around the web. These skills lay a solid groundwork for you to continue your studies in Orchard module development.

--- a/docs/Documentation/How-Orchard-works.markdown
+++ b/docs/Documentation/How-Orchard-works.markdown
@@ -1,7 +1,6 @@
-Building a Web CMS (Content Management System) is unlike building a regular web application: it is more like building an application container. When designing such a system, it is necessary to build extensibility as a first-class feature. This can be a challenge as the very open type of architecture that's necessary to allow for great extensibility may compromise the usability of the application: everything in the system needs to be composable with unknown future modules, including at the user interface level. Orchestrating all those little parts that don't know about each other into a coherent whole is what Orchard is all about.
+Building a Web CMS (Content Management System) is unlike building a regular web application: it is more like building an _application container_. When designing such a system, it is necessary to build extensibility as a first-class feature. This can be a challenge as the very open type of architecture that's necessary to allow for great extensibility may compromise the usability of the application: everything in the system needs to be composable with unknown future modules, including at the user interface level. Orchestrating all those little parts that don't know about each other into a coherent whole is what Orchard is all about.
 
 This document explains the architectural choices we made in Orchard and how they are solving that particular problem of getting both flexibility and a good user experience.
-
 
 # Architecture
 
@@ -30,8 +29,8 @@ This document explains the architectural choices we made in Orchard and how they
 The Orchard CMS is built on existing frameworks and libraries. Here are a few of the most fundamental ones:
 
 - [ASP.NET MVC](http://www.asp.net/mvc): ASP.NET MVC is a modern Web development framework that encourages separation of concerns.
-- [NHibernate](http://nhforge.org/): NHibernate is an object-relational mapping tool. It handles the persistence of the Orchard content items to the database and considerably simplifies the data model by removing altogether the concern of persistence from module development. You can see examples of that by looking at the source code of any core content type, for example Pages.
-- [Autofac](https://github.com/autofac/Autofac): Autofac is an [IoC container](http://en.wikipedia.org/wiki/Inversion_of_control). Orchard makes heavy use of dependency injection. Creating an injectable Orchard dependency is as simple as writing a class that implements IDependency or a more specialized interface that itself derives from IDependency (a marker interface), and consuming the dependency is as simple as taking a constructor parameter of the right type. The scope and lifetime of the injected dependency will be managed by the Orchard framework. You can see examples of that by looking at the source code for IAuthorizationService, RolesBasedAuthorizationService and XmlRpcHandler.
+- [NHibernate](http://nhforge.org/): NHibernate is an object-relational mapping tool. It handles the persistence of the Orchard content items to the database and considerably simplifies the data model by removing altogether the concern of persistence from module development. You can see examples of that by looking at the source code of any core content type, for example _Pages_.
+- [Autofac](https://github.com/autofac/Autofac): Autofac is an [IoC container](http://en.wikipedia.org/wiki/Inversion_of_control). Orchard makes heavy use of dependency injection. Creating an injectable Orchard dependency is as simple as writing a class that implements `IDependency` or a more specialized interface that itself derives from `IDependency` (a marker interface), and consuming the dependency is as simple as taking a constructor parameter of the right type. The scope and lifetime of the injected dependency will be managed by the Orchard framework. You can see examples of that by looking at the source code for `IAuthorizationService`, `RolesBasedAuthorizationService` and `XmlRpcHandler`.
 - [Castle Dynamic Proxy](http://www.castleproject.org/projects/dynamicproxy/): we use Castle for dynamic proxy generation.
 
 The Orchard application and framework are built on top of these foundational frameworks as additional layers of abstraction. They are in many ways implementation details and no knowledge of NHibernate, Castle, or Autofac should be required to work with Orchard.
@@ -42,35 +41,35 @@ The Orchard framework is the deepest layer of Orchard. It contains the engine of
 
 ## Booting Up Orchard
 
-When an Orchard web application spins up, an Orchard Host gets created. A host is a singleton at the app domain level.
+When an Orchard web application spins up, an Orchard `Host` gets created. A host is a singleton at the app domain level.
 
-Next, the host will get the Shell for the current tenant using the ShellContextFactory. Tenants are instances of the application that are isolated as far as users can tell but that are running within the same appdomain, improving the site density. The shell is a singleton at the tenant level and could actually be said to represent the tenant. It's the object that will effectively provide the tenant-level isolation while keeping the module programming model agnostic about multi-tenancy.
+Next, the host will get the `Shell` for the current tenant using the `ShellContextFactory`. Tenants are instances of the application that are isolated as far as users can tell, but that are running within the same appdomain, improving the site density. The shell is a singleton at the tenant level and could actually be said to represent the tenant. It's the object that will effectively provide the tenant-level isolation while keeping the module programming model agnostic about multi-tenancy.
 
-The shell, once created, will get the list of available extensions from the ExtensionManager. Extensions are modules and themes. The default implementation is scanning the modules and themes directories for extensions.
+The shell, once created, will get the list of available extensions from the `ExtensionManager`. Extensions are modules and themes. The default implementation is scanning the modules and themes directories for extensions.
 
-At the same time, the shell will get the list of settings for the tenant from the ShellSettingsManager. The default implementation gets the settings from the appropriate subfolder of `App_Data` but alternative implementations can get those from different places. For example, we have an Azure implementation that is using blob storage instead because `App_Data` is not reliably writable in that environment.
+At the same time, the shell will get the list of settings for the tenant from the `ShellSettingsManager`. The default implementation gets the settings from the appropriate subfolder of `App_Data` but alternative implementations can get those from different places. For example, we have an Azure implementation that is using blob storage instead because `App_Data` is not reliably writable in that environment.
 
-The shell then gets the CompositionStrategy object and uses it to prepare the IoC container from the list of available extensions for the current host and from the settings for the current tenant. The result of this is not an IoC container for the shell, it is a ShellBlueprint, which is a list of dependency, controller and record blueprints.
+The shell then gets the `CompositionStrategy` object and uses it to prepare the IoC container from the list of available extensions for the current host and from the settings for the current tenant. The result of this is not an IoC container for the shell, it is a `ShellBlueprint`, which is a list of dependency, controller and record blueprints.
 
-The list of ShellSettings (that are per tenant) and the ShellBluePrint are then thrown into ShellContainerFactory.CreateContainer to get an ILifetimeScope, which is basically enabling the IoC container to be scoped at the tenant level so that modules can get injected dependencies that are scoped for the current tenant without having to do anything specific.
+The list of `ShellSettings` (that are per-tenant) and the `ShellBluePrint` are then thrown into `ShellContainerFactory.CreateContainer` to get an `ILifetimeScope`, which is basically enabling the IoC container to be scoped at the tenant level so that modules can get injected dependencies that are scoped for the current tenant without having to do anything specific.
 
 ## Dependency Injection
 
-The standard way of creating injectable dependencies in Orchard is to create an interface that derives from IDependency or one of its derived interfaces and then to implement that interface. On the consuming side, you can take a parameter of the interface type in your constructor. The application framework will discover all dependencies and will take care of instantiating and injecting instances as needed.
+The standard way of creating injectable dependencies in Orchard is to create an interface that derives from `IDependency` or one of its derived interfaces and then to implement that interface. On the consuming side, you can take a parameter of the interface type in your constructor. The application framework will discover all dependencies and will take care of instantiating and injecting instances as needed.
 
 There are three different possible scopes for dependencies, and choosing one is done by deriving from the right interface:
 
-- Request: a dependency instance is created for each new HTTP request and is destroyed once the request has been processed. Use this by deriving your interface from IDependency. The object should be reasonably cheap to create.
-- Object: a new instance is created every single time an object takes a dependency on the interface. Instances are never shared. Use this by deriving from ITransientDependency. The objects must be extremely cheap to create.
-- Shell: only one instance is created per shell/tenant. Use this by deriving from ISingletonDependency. Only use this for objects that must maintain a common state for the lifetime of the shell.
+- _Request_: a dependency instance is created for each new HTTP request and is destroyed once the request has been processed. Use this by deriving your interface from `IDependency`. The object should be reasonably cheap to create.
+- _Object_: a new instance is created every single time an object takes a dependency on the interface. Instances are never shared. Use this by deriving from `ITransientDependency`. The objects must be extremely cheap to create.
+- _Shell_: only one instance is created per shell/tenant. Use this by deriving from `ISingletonDependency`. Only use this for objects that must maintain a common state for the lifetime of the shell.
 
 ### Replacing Existing Dependencies
 
-It is possible to replace existing dependencies by decorating your class with the OrchardSuppressDependency attribute, that takes the fully-qualified type name to replace as an argument.
+It is possible to replace existing dependencies by decorating your class with the `OrchardSuppressDependency` attribute, that takes the fully-qualified type name to replace as an argument.
 
 ### Ordering Dependencies
 
-Some dependencies are not unique but rather are parts of a list. For example, handlers are all active at the same time. In some cases you will want to modify the order in which such dependencies get consumed. This can be done by modifying the manifest for the module, using the Priority property of the feature. Here is an example of this:
+Some dependencies are not unique but rather are parts of a list. For example, handlers are all active at the same time. In some cases you will want to modify the order in which such dependencies get consumed. This can be done by modifying the manifest for the module, using the `Priority` property of the feature. Here is an example of this:
 
     
     Features:
@@ -87,11 +86,11 @@ Some dependencies are not unique but rather are parts of a list. For example, ha
 
 Orchard is built on ASP.NET MVC but in order to add things like theming and tenant isolation, it needs to introduce an additional layer of indirection that will present on the ASP.NET MVC side the concepts that it expects and that will on the Orchard side split things on the level of Orchard concepts.
 
-For example, when a specific view is requested, our LayoutAwareViewEngine kicks in. Strictly speaking, it's not a new view engine as it is not concerned with actual rendering, but it contains the logic to find the right view depending on the current theme and then it delegates the rendering work to actual view engines.
+For example, when a specific view is requested, our `LayoutAwareViewEngine` kicks in. Strictly speaking, it's not a new view engine as it is not concerned with actual rendering, but it contains the logic to find the right view depending on the current theme and then it delegates the rendering work to actual view engines.
 
 Similarly, we have route providers, model binders and controller factories whose work is to act as a single entry point for ASP.NET MVC and to dispatch the calls to the properly scoped objects underneath.
 
-In the case of routes, we can have n providers of routes (typically coming from modules) and one route publisher that will be what talks to ASP.NET MVC. The same thing goes for model binders and controller factories.
+In the case of routes, we can have `n` providers of routes (typically coming from modules) and one route publisher that will be what talks to ASP.NET MVC. The same thing goes for model binders and controller factories.
 
 ## Content Type System
 
@@ -99,19 +98,19 @@ Contents in Orchard are managed under an actual type system that is in some ways
 
 ### Types, Parts, and Fields
 
-Orchard can handle arbitrary content types, including some that are dynamically created by the site administrator in a code-free manner. Those content types are aggregations of content parts that each deal with a particular concern. The reason for that is that many concerns span more than one content type.
+Orchard can handle arbitrary content types, including some that are dynamically created by the site administrator in a code-free manner. Those _content types_ are aggregations of _content parts_ that each deal with a particular concern. The reason for that is that many concerns span more than one content type.
 
-For example, a blog post, a product and a video clip might all have a routable address, comments and tags. For that reason, the routable address, comments and tags are each treated in Orchard as a separate content part. This way, the comment management module can be developed only once and apply to arbitrary content types, including those that the author of the commenting module did not know about.
+For example, a blog post, a product and a video clip might all have a routable address, comments and tags. For that reason, the routable address, comments and tags are each treated in Orchard as a separate content part. This way, the comment management module needs to be developed only once, and can be applied to arbitrary content types, including those that the author of the commenting module did not know about.
 
-Parts themselves can have properties and content fields. Content fields are also reusable in the same way that parts are: a specific field type will be typically used by several part and content types. The difference between parts and fields resides in the scale at which they operate and in their semantics.
+Parts themselves can have _properties_ and _content fields_. Content fields are also reusable in the same way that parts are: a specific field type will be typically used by several part and content types. The difference between parts and fields resides in the scale at which they operate and in their semantics.
 
 Fields are a finer grain than parts. For example, a field type might describe a phone number or a coordinate, whereas a part would typically describe a whole concern such as commenting or tagging.
 
-But the important difference here is semantics: you want to write a part if it implements an "is a" relationship, and you would write a field if it implements a "has a" relationship.
+But the important difference here is semantics: you want to write a part if it implements an **is a** relationship, and you would write a field if it implements a **has a** relationship.
 
 For example, a shirt **is a** product and it **has a** SKU and a price. You wouldn't say that a shirt has a product or that a shirt is a price or a SKU.
 
-From that you know that the Shirt content type will be made of a Product part, and that the Product part will be made from a Money field named "price" and a String field named SKU.
+From that you know that the _Shirt_ content type will be made of a _Product_ part, and that the _Product_ part will be made from a _Money_ field named "price" and a _String_ field named SKU.
 
 Another difference is that you have only one part of a given type per content type, which makes sense in light of the "is a" relationship, whereas a part can have any number of fields of a given type. Another way of saying that is that fields on a part are a dictionary of strings to values of the field's type, whereas the content type is a list of part types (without names).
 
@@ -119,33 +118,33 @@ This gives another way of choosing between part and field: if you think people w
 
 ### Anatomy of a Content Type
 
-A content type, as we've seen, is built from content parts. Content parts, code-wise, are typically associated with:
+A _content type_, as we've seen, is built from _content parts_. Content parts, code-wise, are typically associated with:
 
 - a Record, which is a POCO representation of the part's data
-- a model class that is the actual part and that derives from `ContentPart<T>` where T is the record type
+- a model class that is the actual part and that derives from `ContentPart<T>`, where `T` is the record type
 - a repository. The repository does not need to be implemented by the module author as Orchard will be able to just use a generic one.
-- handlers. Handlers implement IContentHandler and are a set of event handlers such as OnCreated or OnSaved. Basically, they hook onto the content item's lifecycle to perform a number of tasks. They can also participate in the actual composition of the content items from their constructors. There is a Filters collection on the base ContentHandler that enable the handler to add common behavior to the content type.  
-For example, Orchard provides a StorageFilter that makes it very easy to declare how persistence of a content part should be handled: just do `Filters.Add(StorageFilter.For(myPartRepository));` and Orchard will take care of persisting to the database the data from myPartRepository.  
-Another example of a filter is the ActivatingFilter that is in charge of doing the actual welding of parts onto a type: calling `Filters.Add(new ActivatingFilter<BodyAspect>(BlogPostDriver.ContentType.Name));` adds the body content part to blog posts.
-- drivers. Drivers are friendlier, more specialized handlers (and as a consequence less flexible) and are associated with a specific content part type (they derive from `ContentPartDriver<T>` where T is a content part type). Handlers on the other hand do not have to be specific to a content part type. Drivers can be seen as controllers for a specific part. They typically build shapes to be rendered by the theme engine.
+- handlers. Handlers implement `IContentHandler` and are a set of event handlers such as `OnCreated` or `OnSaved`. Basically, they hook onto the content item's lifecycle to perform a number of tasks. They can also participate in the actual composition of the content items from their constructors. There is a `Filters` collection on the base `ContentHandler` that enables the handler to add common behavior to the content type.  
+  For example, Orchard provides a `StorageFilter` that makes it very easy to declare how persistence of a content part should be handled: just do `Filters.Add(StorageFilter.For(myPartRepository));` and Orchard will take care of persisting to the database the data from `myPartRepository`.  
+  Another example of a filter is the `ActivatingFilter` that is in charge of doing the actual welding of parts onto a type: calling `Filters.Add(new ActivatingFilter<BodyAspect>(BlogPostDriver.ContentType.Name));` adds the body content part to blog posts.
+- drivers. Drivers are friendlier, more specialized handlers (and as a consequence less flexible) and are associated with a specific content part type (they derive from `ContentPartDriver<T>` where `T` is a content part type). Handlers on the other hand do not have to be specific to a content part type. Drivers can be seen as controllers for a specific part. They typically build shapes to be rendered by the theme engine.
 
 ## Content Manager
-All contents are accessed in Orchard through the ContentManager object, which is how it becomes possible to use contents of a type you don't know in advance.
+All contents are accessed in Orchard through the `ContentManager` object, which is how it becomes possible to use contents of a type you don't know in advance.
 
-ContentManager has methods to query the content store, to version contents and to manage their publication status.
+`ContentManager` has methods to query the content store, to version contents and to manage their publication status.
 
 ## Transactions
 
-Orchard is automatically creating a transaction for each HTTP request. That means that all operations that happen during a request are part of an "ambient" transaction. If code during that request aborts that transaction, all data operations will be rolled back. If the transaction is never explicitly cancelled on the other hand, all operations get committed at the end of the request without an explicit commit.
+Orchard automatically creates a transaction for each HTTP request. That means that all operations that happen during a request are part of an "ambient" transaction. If code during that request aborts that transaction, all data operations will be rolled back. If the transaction is never explicitly cancelled on the other hand, all operations get committed at the end of the request without an explicit commit.
 
 
 ## Request Lifecycle
 
 In this section, we'll take the example of a request for a specific blog post.
 
-When a request comes in for a specific blog post, the application first looks at the available routes that have been contributed by the various modules and finds the blog module's matching route. The route can then resolve the request to the blog post controller's item action, which will look up the post from the content manager. The action then gets a Page Object Model (POM) from the content manager (by calling BuildDisplay) based on the main object for that request, the post that was retrieved from the content manager.
+When a request comes in for a specific blog post, the application first looks at the available routes that have been contributed by the various modules and finds the blog module's matching route. The route can then resolve the request to the blog post controller's item action, which will look up the post from the content manager. The action then gets a Page Object Model (POM) from the content manager (by calling `BuildDisplay`) based on the main object for that request, the post that was retrieved from the content manager.
 
-A blog post has its own controller, but that is not the case for all content types. For example, dynamic content types will be served by the more generic ItemController from the Core Routable part. The Display action of the ItemController does almost the same thing that the blog post controller was doing: it gets the content item from the content manager by slug and then builds the POM from the results.
+A blog post has its own controller, but that is not the case for all content types. For example, dynamic content types will be served by the more generic `ItemController` from the Core `Routable` part. The `Display` action of the `ItemController` does almost the same thing that the blog post controller was doing: it gets the content item from the content manager by slug and then builds the POM from the results.
 
 The layout view engine will then resolve the right view depending on the current theme and using the model's type together with Orchard conventions on view naming.
 
@@ -155,11 +154,11 @@ The actual rendering is done by the theme engine that is going to find the right
 
 ## Widgets
 
-Widgets are content types that have the Widget content part and the widget stereotype. Like any other content types, they are composed of parts and fields. That means that they can be edited using the same edition and rendering logic as other content types. They also share the same building blocks, which means that any existing content part can potentially be reused as part of a widget almost for free.
+Widgets are content types that have the `Widget` content part and the `widget` stereotype. Like any other content type, they are composed of parts and fields. That means that they can be edited using the same edition and rendering logic as other content types. They also share the same building blocks, which means that any existing content part can potentially be reused as part of a widget almost for free.
 
-Widgets are added to pages through widget layers. Layers are sets of widgets. They have a name, a rule that determines what pages of the site they should appear on, and a list of widgets and associated zone placement and ordering, and settings.
+Widgets are added to pages through _widget layers_. Layers are sets of widgets. They have a name, a rule that determines what pages of the site they should appear on, and a list of widgets and associated zone placement and ordering, and settings.
 
-The rules attached to each of the layers are expressed with IronRuby expressions. Those expressions can use any of the IRuleProvider implementations in the application. Orchard ships with two out of the box implementations: url and authenticated.
+The rules attached to each of the layers are expressed with IronRuby expressions. Those expressions can use any of the `IRuleProvider` implementations in the application. Orchard ships with two out of the box implementations: "url" and "authenticated".
 
 ## Site Settings
 
@@ -177,7 +176,7 @@ This is just one implementation of the Orchard event bus. When an extensibility 
 
 ## Commands
 
-Many actions on an Orchard site can be performed from the command line as well as from the admin UI. These commands are exposed by the methods of classes implementing ICommandHandler that are decorated with a CommandName attribute.
+Many actions on an Orchard site can be performed from the command line as well as from the admin UI. These commands are exposed by the methods of classes implementing `ICommandHandler` that are decorated with a `CommandName` attribute.
 
 The Orchard command line tool discovers available commands at runtime by simulating the web site environment and inspecting the assemblies using reflection. The environment in which the commands run is as close as possible to the actual running site.
 
@@ -187,13 +186,13 @@ Search and indexing are implemented using Lucene by default, although that defau
 
 ## Caching
 
-The cache in Orchard relies on the ASP.NET cache, but we expose a helper API that can be used through a dependency of type ICache, by calling the Get method. Get takes a key and a function that can be used to generate the cache entry's value if the cache doesn't already contains the requested entry.
+The cache in Orchard relies on the ASP.NET cache, but we expose a helper API that can be used through a dependency of type `ICache`, by calling the `Get` method. `Get` takes a key and a function that can be used to generate the cache entry's value if the cache doesn't already contain the requested entry.
 
 The main advantage of using the Orchard API for caching is that it works per tenant transparently.
 
 ## File Systems
 
-The file system in Orchard is abstracted so that storage can be directed to the physical file system or to an alternate storage such as Azure blob storage, depending on the environment. The Media module is an example of a module that uses that abstracted file system.
+The file system in Orchard is abstracted so that storage can be directed to the physical file system or to an alternate storage such as Azure blob storage, depending on the environment. The `Media` module is an example of a module which uses that abstracted file system.
 
 ## Users and Roles
 
@@ -206,58 +205,58 @@ Every module can expose a set of permissions as well as how those permissions sh
 
 ## Tasks
 
-Modules can schedule tasks by calling CreateTask on a dependency of type IScheduledTaskManager. The task can then be executed by implementing IScheduledTaskHandler. The Process method can examine the task type name and decide whether to handle it.
+Modules can schedule tasks by calling `CreateTask` on a dependency of type `IScheduledTaskManager`. The task can then be executed by implementing `IScheduledTaskHandler`. The `Process` method can examine the task type name and decide whether to handle it.
 
-Tasks are being run on a separate thread that comes from the ASP.NET thread pool.
+Tasks are run on a separate thread that comes from the ASP.NET thread pool.
 
 ## Notifications
 
-Modules can surface messages to the admin UI by getting a dependency on INotifier and calling one of its methods. Multiple notifications can be created as part of any request.
+Modules can surface messages to the admin UI by getting a dependency on `INotifier` and calling one of its methods. Multiple notifications can be created as part of any request.
 
 ## Localization
 
-Localization of the application and its modules is done by wrapping string resources in a call to the T method: `@T("This string can be localized")`. See [Using the localization helpers](Using-the-localization-helpers) for more details and guidelines. Orchard's resource manager can load localized resource strings from PO files located in specific places in the application.
+Localization _of the application and its modules_ is done by wrapping string resources in a call to the T method: `@T("This string can be localized")`. See [Using the localization helpers](Using-the-localization-helpers) for more details and guidelines. Orchard's resource manager can load localized resource strings from `.po` files located in specific places in the application.
 
-Content item localization is done through a different mechanism: localized versions of a content item are physically separate content items that are linked together by a special part.
+_Content item_ localization is done through a different mechanism: localized versions of a content item are physically separate content items that are linked together by a special part.
 
 The current culture to use is determined by the culture manager. The default implementation returns the culture that has been configured in site settings, but an alternate implementation could get it from the user profile or from the browser's settings.
 
 ## Logging
 
-Logging is done through a dependency of type ILogger. Different implementations can send the log entries to various storage types. Orchard comes with an implementation that uses [Castle.Core.Logging](https://github.com/castleproject/Windsor/blob/master/docs/logging-facility.md) for logging.
+Logging is done through a dependency of type `ILogger`. Different implementations can send the log entries to various storage types. Orchard comes with an implementation that uses [Castle.Core.Logging](https://github.com/castleproject/Windsor/blob/master/docs/logging-facility.md) for logging.
 
 # Orchard Core
 
-The Orchard.Core assembly contains a set of modules that are necessary for Orchard to run. Other modules can safely take dependencies on these modules that will always be available.
+The `Orchard.Core` assembly contains a set of modules that are necessary for Orchard to run. Other modules can safely take dependencies on these modules that will always be available.
 
-Examples of core modules are feeds, navigation or routable.
+Examples of core modules are `Feeds`, `Navigation` or `Dashboard`.
 
 # Modules
 The default distribution of Orchard comes with a number of built-in modules such as blogging or pages, but third party modules are being built as well.
 
-A module is just an ASP.NET MVC area with a manifest.txt file that is extending Orchard.
+A module is just an ASP.NET MVC area with a `Module.txt` file that is extending Orchard.
 
 A module typically contains event handlers, content types and their default rendering templates as well as some admin UI.
 
-Modules can be dynamically compiled from source code every time a change is made to their csproj file or to one of the files that the csproj file references. This enables a "notepad" style of development that does no require explicit compilation by the developer or even the use of an IDE such as Visual Studio.
+Modules can be dynamically compiled from source code every time a change is made to their `.csproj` file or to one of the files that the csproj file references. This enables a "notepad" style of development that does not require explicit compilation by the developer or even the use of an IDE such as Visual Studio.
 
-Modules must be placed in the Modules folder (Orchard.Web/Modules/MyModule) and the folder name *must* match the name of the compiled DLL produced by the project.  So, if you have a custom module project called My.Custom.Module.csproj and it compiles to My.Custom.Module.dll, then the module root folder must be named My.Custom.Module. [~/Modules/My.Custom.Module/]
+Modules must be placed in the `Modules` folder (e.g. `Orchard.Web/Modules/MyModule`) and the folder name *must* match the name of the compiled DLL produced by the project.  So, if you have a custom module project called `My.Custom.Module.csproj` and it compiles to `My.Custom.Module.dll`, then the module root folder must be named `My.Custom.Module`. [`~/Modules/My.Custom.Module/`]. There is support for defining [Custom Folders](Orchard-module-loader-and-dynamic-compilation#custom-folders).
 
 # Themes
 
 It is a basic design principle in Orchard that all the HTML that it produces can be replaced from themes, including markup produced by modules. Conventions define what files must go where in the theme's file hierarchy.
 
-The whole rendering mechanism in Orchard is based on shapes. The theme engine's job is to find the current theme and given that theme determine what the best way to render each shape is. Each shape can have a default rendering that may be defined by a module as a template in the views folder or as a shape method in code. That default rendering may be overridden by the current theme. The theme does that by having its own version of a template for that shape or its own shape method for that shape.
+The whole rendering mechanism in Orchard is based on _shapes_. The theme engine's job is to find the current theme and, given that theme, determine what the best way to render each shape is. Each shape can have a default rendering that may be defined by a module as a template in the _views_ folder or as a shape method in code. That default rendering may be overridden by the current theme. The theme does that by having its own version of a template for that shape or its own shape method for that shape.
 
-Themes can have a parent, which enables child themes to be specializations or adaptations of a parent theme. Orchard comes with a base theme called the Theme Machine that has been designed to make it easy to use as a parent theme.
+Themes can have a parent, which enables child themes to be specializations or adaptations of a parent theme. Orchard comes with a base theme called the _Theme Machine_ that has been designed to make it easy to use as a parent theme.
 
-Themes can contain code in much the same way modules do: they can have their own csproj file and benefit from dynamic compilation. This enables themes to define shape methods, but also to expose admin UI for any settings they may have.
+Themes can contain code in much the same way modules do: they can have their own `.csproj` file and benefit from dynamic compilation. This enables themes to define shape methods, but also to expose admin UI for any settings they may have.
 
-The selection of the current theme is done by classes implementing IThemeSelector, which return a theme name and a priority for any request. This allows many selectors to contribute to the choice of the theme. Orchard comes with four implementations of IThemeSelector:
+The selection of the current theme is done by classes implementing `IThemeSelector`, which returns a theme name and a priority for any request. This allows many selectors to contribute to the choice of the theme. Orchard comes with four implementations of `IThemeSelector`:
 
-- SiteThemeSelector selects the theme that is currently configured for the tenant or site with a low priority.
-- AdminThemeSelector takes over and returns the admin theme with a high priority whenever the current URL is an admin URL.
-- PreviewThemeSelector overrides the site's current theme with the theme being previewed if the current user is the one that initiated the theme preview.
-- SafeModeThemeSelector is the only selector available when the application is in "safe mode", which happens typically during setup. It has a very low priority.
+- `SiteThemeSelector` selects the theme that is currently configured for the tenant or site with a low priority.
+- `AdminThemeSelector` takes over and returns the admin theme with a high priority whenever the current URL is an admin URL.
+- `PreviewThemeSelector` overrides the site's current theme with the theme being previewed if the current user is the one that initiated the theme preview.
+- `SafeModeThemeSelector` is the only selector available when the application is in "safe mode", which happens typically during setup. It has a very low priority.
 
 An example of a theme selector might be one that promotes a mobile theme when the user agent is recognized to belong to a mobile device.

--- a/docs/Documentation/Manifest-files.markdown
+++ b/docs/Documentation/Manifest-files.markdown
@@ -1,5 +1,5 @@
 
-In the Orchard CMS, modules and themes are important tools for extending and customizing an application. Every module and theme is required to have a manifest, which is a text file named _module.txt_ or _theme.txt_ that resides in the root folder of the associated module or theme. A manifest stores metadata that Orchard uses to describe modules and themes to the system, such as name, version, description, author, and tags.
+In the Orchard CMS, modules and themes are important tools for extending and customizing an application. Every module and theme is required to have a manifest, which is a text file named `Module.txt` or `Theme.txt` that resides in the root folder of the associated module or theme. A manifest stores metadata that Orchard uses to describe modules and themes to the system, such as name, version, description, author, and tags.
 
 This topic is a reference for manifest files. If you create a custom module or theme, or if you write code that accesses modules or themes, you must understand the metadata fields in a manifest. The data in a manifest is structured into name-value pairs in the form `Field Name: Value`. 
 
@@ -7,13 +7,13 @@ The following sections describe the available fields in a manifest for themes an
 
 ## Module manifest fields
 
-The manifest for a module should be called `module.txt` and should be located in the root of the project. 
+The manifest for a module should be called `Module.txt` and should be located in the root of the project. 
 
 A module's manifest is made up of an overall description of the package itself and then an optional repeating section describing each of the individual features. 
 
 The module can be comprised of a default single feature or a group of individually defined features. This allows module developers to specify separate areas of the module and allow users to enable them on a per-feature basis.
 
-### Main module.txt fields
+### Main `Module.txt` fields
 
 Some of the fields may be overridden if a module defines multiple features. These are detailed in the [`Features:` sub-section fields](manifest-files#ModuletxtFeaturessubsectionfields) table below.
 

--- a/docs/Documentation/Orchard-module-loader-and-dynamic-compilation.markdown
+++ b/docs/Documentation/Orchard-module-loader-and-dynamic-compilation.markdown
@@ -2,110 +2,110 @@
 
 As a composable CMS, Orchard has the ability to load an arbitrary set of modules (also known as "extensions") at run-time. One of the goals of the 0.5 release was to make the process of installing and updating modules as easy as possible. 
 
-Orchard, as any ASP.NET MVC application, supports loading module compiled as assemblies using Visual Studio. Orchard also offers a customized module loading strategy which, for example, allows loading assemblies for modules without having to deploy them in the "~/bin" folder.
+Orchard, like any ASP.NET MVC application, supports loading modules compiled as assemblies using Visual Studio. Orchard also offers a customized module loading strategy which, for example, allows loading assemblies for modules without having to deploy them in the `~/bin` folder.
 
-In addition to that, Orchard supports (this is still somewhat experimental) the ability to dynamically compile modules deployed as source code only.  This is more flexible than deploying binaries, and enables some interesting scenarios such as "in place" code customization without having to use Visual Studio. This is somewhat similar to the ASP.NET "App_Code" directory, except Orchard supports multiple "logical folder" (typically one per module) independently.
+In addition to that, Orchard supports the ability to dynamically compile modules deployed as source code only (this is still somewhat experimental).  This is more flexible than deploying binaries, and enables some interesting scenarios such as "in place" code customization without having to use Visual Studio. This is somewhat similar to the ASP.NET `App_Code` directory, except Orchard supports multiple "logical folders" (typically one per module) independently.
 
-The goal of this section is to describe at a technical level how Orchard load modules in the 0.5 release. This feature is often referred to as "Orchard Dynamic Compilation", even though technically dynamic compilation is only involved in very specific cases.
+The goal of this section is to describe at a technical level how Orchard loads modules in the 0.5 release. This feature is often referred to as "Orchard Dynamic Compilation", even though technically dynamic compilation is only involved in very specific cases.
 
 # High Level Overview
 
-When an Orchard application starts, the Orchard Framework (the ExtensionLoaderCoordinator class to be precise) needs to figure out what are the modules installed in the Web Site and activate them (typically by loading their assembly).
+When an Orchard application starts, the Orchard Framework (the `ExtensionLoaderCoordinator` class to be precise) needs to figure out what are the modules installed in the Web Site and activate them (typically by loading their assembly).
 
 At a high level, this process can be divided in 3 distinct phases:
 
-* Discovery: figure out what are the modules present in the web site
-* Activation: figure out what strategy to use to "activate" (or load) each module
-* References Resolution: figure out what are the assembly references needed to be activated for each module. This phase is technically part of the "Activation" phase, but it is easier to think about the problem of reference resolution as a separate concern.
+* _Discovery_: figure out what are the modules present in the web site
+* _Activation_: figure out what strategy to use to "activate" (or load) each module
+* _References Resolution_: figure out what are the assembly references needed to be activated for each module. This phase is technically part of the "Activation" phase, but it is easier to think about the problem of reference resolution as a separate concern.
 
 Once modules are properly activated, they are further examined to detect and enable individual _features_, but this is a topic for another section.
 
 # Discovery 
 
-The list of available extensions in an Orchard installation is built by searching various folders of the file system for "**module.txt**" and "**theme.txt**" files. The folders looked at by default are listed in the following sections.
+The list of available extensions in an Orchard installation is built by searching various folders of the file system for `Module.txt` and `Theme.txt` files. The folders looked at by default are listed in the following sections.
 
-##  "~/Modules" Folder 
+##  `~/Modules` Folder 
 
-The "~/Modules" folder is intended to contain the vast majority of Orchard modules. The convention is that each module is stored in a sub-folder named "&lt;ModuleName&gt;" containing a single "module.txt" file.  Packaging, distribution and sharing of modules is only supported for modules in the "~/Modules" folder.
+The `~/Modules` folder is intended to contain the vast majority of Orchard modules. The convention is that each module is stored in a sub-folder named `<ModuleName>` containing a single `Module.txt` file.  Packaging, distribution and sharing of modules is only supported for modules in the `~/Modules` folder.
 
-##  "~/Core" Folder 
+##  `~/Core` Folder 
 
-The "~/Core" folder contains, by convention, modules defined in the "Orchard.Core" assembly. These modules are part of the "Core" Orchard system and are not intended to be modified as freely as modules in the "~/Modules" folder.
+The `~/Core` folder contains, by convention, modules defined in the `Orchard.Core` assembly. These modules are part of the "Core" Orchard system and are not intended to be modified as freely as modules in the `~/Modules` folder.
 
-##  "~/Themes" Folder 
+##  `~/Themes` Folder 
 
-The "~/Themes" folder is intended to contain Orchard Themes. Wrt to dynamic compilation, Themes are treated almost exactly the same as Modules, except that Themes don't have to have code (assembly in bin or .csproj file). For the rest of this page, when we refer to "Module", it should be understand that the concept applies to "Theme" the same way.
+The `~/Themes` folder is intended to contain Orchard Themes. With respect to dynamic compilation, Themes are treated almost exactly the same as Modules, except that Themes don't have to have code (assembly in `bin` or `.csproj` file). For the rest of this page, when we refer to "Module", it should be understand that the concept applies to "Theme" the same way.
 
 ## Custom Folders
 
-Orchard 1.10 introduced a new feature that allows the loading of extensions from custom-defined folders outside of the ones listed above by adding the `ExtensionLocations` service that is utilised by each extension loader (see the Loaders in the Activation section below).
+Orchard 1.10 introduced a new feature that allows the loading of extensions from custom-defined folders outside of the ones listed above by adding the `ExtensionLocations` service that is utilised by each extension loader (see the `Loaders` in the `Activation` section below).
 
-Additional extension folders can be configured by defining an AppSetting (e.g. by adding it to the root web.config file, which contains appropriate examples) with the `key` "Modules" and/or "Themes" with their respective `value` being e.g. "~/Modules.Custom" and/or "~/Themes.Custom".
+Additional extension folders can be configured by defining an `AppSetting` (e.g. by adding it to the root `web.config` file, which contains appropriate examples) with the key `Modules` and/or `Themes` with their respective `value` being e.g. `~/Modules.Custom` and/or `~/Themes.Custom`.
 
 ##  Example 
 
-Here is an example of an Orchard installation which contains the following extensions: Common and Localization (Core modules), Orchard.Azure and Orchard.Caching (built-in modules), SafeMode and TheAdmin (built-in themes), MyModule1 and MyModule2 (custom modules), MyBaseTheme and MyTheme (custom themes).
+Here is an example of an Orchard installation which contains the following extensions: `Common` and `Localization` (`Core` modules), `Orchard.Azure` and `Orchard.Caching` (built-in modules), `SafeMode` and `TheAdmin` (built-in themes), `MyModule1` and `MyModule2` (custom modules), `MyBaseTheme` and `MyTheme` (custom themes).
 
     
     Root (Orchard.Web)
       Core
         Common
-          module.txt  <= "Common" module from "Core"
+          Module.txt  <= "Common" module from "Core"
         Localization
-          module.txt  <= "Localization" module from "Core"
+          Module.txt  <= "Localization" module from "Core"
       Modules
         Orchard.Azure
-          module.txt  <= "Orchard.Azure" module
+          Module.txt  <= "Orchard.Azure" module
         Orchard.Caching
-          module.txt  <= "Orchard.Caching" module
+          Module.txt  <= "Orchard.Caching" module
 	  Modules.Custom
 		MyModule1
-		  module.txt  <= "MyModule1" module
+		  Module.txt  <= "MyModule1" module
 		MyModule2
-		  module.txt  <= "MyModule2" module
+		  Module.txt  <= "MyModule2" module
       Themes
         SafeMode
-          theme.txt  <= "SafeMode" theme
+          Theme.txt  <= "SafeMode" theme
         TheAdmin
-          theme.txt  <= "TheAdmin" theme
+          Theme.txt  <= "TheAdmin" theme
 	  Themes.Custom
         MyBaseTheme
-          theme.txt  <= "MyBaseTheme" theme
+          Theme.txt  <= "MyBaseTheme" theme
         MyTheme
-          theme.txt  <= "MyTheme" theme
+          Theme.txt  <= "MyTheme" theme
 
 
 # Activation 
 
-Once Orchard has collected all the "Module.txt" files from the discovery phase, Orchard uses distinct strategies (or "Module Loaders") to load these modules in memory. Internally, the act of "loading a module" is an activity that takes a "module.txt" file as input and returns a list of "System.Type" as output. Note that this is slightly more generic than simply returning a "System.Assembly", as it allows Orchard to support multiple modules per assembly. For example, the "Orchard.Core.dll" assembly currently contains about 10 modules.
+Once Orchard has collected all the `Module.txt` files from the discovery phase, Orchard uses distinct strategies (or "Module Loaders") to load these modules in memory. Internally, the act of "loading a module" is an activity that takes a `Module.txt` file as input and returns a list of `System.Type` as output. Note that this is slightly more generic than simply returning a `System.Assembly`, as it allows Orchard to support multiple modules per assembly. For example, the `Orchard.Core.dll` assembly currently contains about 10 modules.
 
 The Orchard framework currently implements the following loaders:
 
 ##  "Referenced Module" Loader 
 
-This loader looks in in "~/bin" directory for a assembly name corresponding to the module name specified in "module.txt". If the assembly exists, it is loaded and all its types are returned. This loader is useful when someone wants to deploy an Orchard web site where all modules are pre-compiled and stored in "~/bin", in a typical "asp.net web application" way.
+This loader looks in `~/bin` directory for a assembly name corresponding to the module name specified in `Module.txt`. If the assembly exists, it is loaded and all its types are returned. This loader is useful when someone wants to deploy an Orchard web site where all modules are pre-compiled and stored in `~/bin`, in a typical "asp.net web application" way.
 
 ##  "Core Module" Loader 
 
-If "module.txt" indicates a module from the "~/Core" folder, the CoreExtensionLoader returns the types from the "Orchard.Core.&lt;moduleMame&gt;" namespace of the "Orchard.Core" assembly. "Orchard.Core" is a special assembly containing modules that are "core" to the system, i.e. offering basic functionality on top of the Orchard Framework.
+If `Module.txt` indicates a module from the `~/Core` folder, the CoreExtensionLoader returns the types from the `Orchard.Core.<ModuleName>` namespace of the `Orchard.Core` assembly. `Orchard.Core` is a special assembly containing modules that are "core" to the system, i.e. offering basic functionality on top of the Orchard Framework.
 
 ##  "Precompiled Module" Loader 
 
-If "module.txt" indicates a module from the "~/Modules" folder, the PrecompiledExtensionLoader looks for an assembly named "&lt;ModuleName&gt;" in the "~/Modules/&lt;ModuleName&gt;/bin" folder. If the file exists, it's is copied to the `~/App_Data/Dependencies` folder, which is a special folder used by ASP.NET to look for additional assemblies outside of the traditional "~/bin" folder.
+If `Module.txt` indicates a module from the `~/Modules` folder, the `PrecompiledExtensionLoader` looks for an assembly named `<ModuleName>` in the `~/Modules/<ModuleName>/bin` folder. If the file exists, its is copied to the `~/App_Data/Dependencies` folder, which is a special folder used by ASP.NET to look for additional assemblies outside of the traditional `~/bin` folder.
 
 ##  "Dynamic Module" Loader 
 
-If "module.txt" indicates a module from the "~/Modules" folder, the "Dynamic Module" loader looks for a file named "<ModuleName>.csproj" in the "~/Modules/&lt;ModuleName&gt;" folder. If the file exists, the loader will use the Orchard build manager for .csproj files to compile the file into an assembly and return all the types from that assembly.
+If `Module.txt` indicates a module from the `~/Modules` folder, the "Dynamic Module" loader looks for a file named `<ModuleName>.csproj` in the `~/Modules/<ModuleName>` folder. If the file exists, the loader will use the Orchard build manager for `.csproj` files to compile the file into an assembly and return all the types from that assembly.
 
-Note: This loader is the only one in the system performing what is often referred to as "dynamic compilation", and is indeed optional if modules have been pre-compiled.
+Note: This loader is the only one in the system performing what is often referred to as `dynamic compilation`, and is indeed optional if modules have been pre-compiled.
 
 ##  Loader Disambiguation 
 
 Since there is potentially more than one loader able to load a given module, Orchard has to have a way to resolve the ambiguity, i.e. pick the "right" loader.  Each loader has the ability to return a "date of last modification" for each module they can load.  For a given module, if there are multiple candidate loaders, Orchard will pick the loader which returns the most "recent" date of last modification.
 
-For example, a given module can be distributed with both full source code (including .csproj file) **and** compiled into an assembly in its "bin" directory.  The first time the module is loaded, Orchard will pick the loader for the assembly in "bin" since it's very likely the assembly was compiled after the last source code change was made.  However, if any change was made to the source code afterward, the "Dynamic Module" loader will return the date of the most recently modified file (either the source file or csproj), and Orchard will pick that loader for the given module.  
+For example, a given module can be distributed with both full source code (including `.csproj` file) **and** compiled into an assembly in its `bin` directory.  The first time the module is loaded, Orchard will pick the loader for the assembly in `bin` since it's very likely the assembly was compiled after the last source code change was made.  However, if any change was made to the source code afterward, the "Dynamic Module" loader will return the date of the most recently modified file (either the source file or `.csproj`), and Orchard will pick that loader for the given module.  
 
-Note that the "Core Module" loader is never ambiguous, because there is only one way to load these modules. The ambiguity can only arise for modules in the "~/Modules" directory.
+Note that the "Core Module" loader is never ambiguous, because there is only one way to load these modules. The ambiguity can only arise for modules in the `~/Modules` directory.
 
 ##  Example 
 
@@ -117,21 +117,21 @@ Note that the "Core Module" loader is never ambiguous, because there is only one
         Foo.dll
       Core           
         Common        <= "Core Module" loader
-          module.txt
+          Module.txt
         Localization  <= "Core Module" loader
-          module.txt
+          Module.txt
       Modules
         Foo           <= "Reference Module" loader (because a "~/bin/Foo.dll" file exists)
-          module.txt
+          Module.txt
         Bar           <= "Precompiled Module" loader (because a "~/Modules/Bar/bin/Bar.dll" file exists)
           bin
             Bar.dll
-          module.txt
+          Module.txt
         Baz           <= "Dynamic Module" loader (because a "~/Modules/Baz/Baz.csproj" file exists)
           Controller
              BazControler.cs
           Baz.csproj
-          module.txt
+          Module.txt
 
 ## Disabling the "Dynamic Module" loader
 
@@ -163,7 +163,7 @@ Otherwise use the command line tool to build the website, which will have the sa
 
 #  References Resolution 
 
-(TODO: Explain how Orchard figures out references by looking at the "References" section of the csproj file as well as looking at additional assembly binaries dropped in each module "bin" directory)
+(TODO: Explain how Orchard figures out references by looking at the "References" section of the csproj file as well as looking at additional assembly binaries dropped in each module `bin` directory)
 
 #  Change of Configuration Detection 
 
@@ -174,13 +174,13 @@ When a change is detected, the current module configuration is discarded and mod
 
 #  Rendering Web Forms Views 
 
-(TODO: Explain that Orchard uses a custom virtual path provider to insert custom "Assembly Src=xx" and "Assembly Name=xxx" directive when reading .ascx and .aspx files)
+(TODO: Explain that Orchard uses a custom virtual path provider to insert custom `Assembly Src=xx` and `Assembly Name=xxx` directive when reading `.ascx` and `.aspx` files)
 
 #  Rendering Razor Views 
 
 (TODO: Explain that Orchard uses a Razor custom API to add Module dependencies to Views)
 
 
-#  The `~/App_Data/Dependencies/Dependencies.xml` File 
+#  The `~/App_Data/Dependencies/Dependencies.xml` file 
 
-This file contains the list of modules, their loader and their resolved references of the "last known good" configuration of module, i.e. the last time Orchard successfully loaded all modules of the application.  Examining the content of this file can be useful for debugging purposes, i.e. if a the latest version of a module doesn't seem to be loaded, for example.
+This file contains the list of modules, their loader and their resolved references of the "last known good" configuration of module, i.e. the last time Orchard successfully loaded all modules of the application.  Examining the content of this file can be useful for debugging purposes, e.g. if the latest version of a module doesn't seem to be loaded.

--- a/docs/Documentation/Setting-up-for-a-lesson.markdown
+++ b/docs/Documentation/Setting-up-for-a-lesson.markdown
@@ -4,7 +4,7 @@ If you don't have a it on your system then grab a copy of [Microsoft Visual Stud
 ## Step 2 - Install Git Extensions
 Every developer should have [Git Extensions](https://github.com/gitextensions/gitextensions/releases/latest) installed on their machine.
 
-This is the easiest way to quickly clone the Orchard source code onto your dev machine. Its the easiest way to keep up to date when new code is released. As a bonus, if you haven't got to grips with Git and GitHub this will gently introduce you to the whole process.
+This is the easiest way to quickly clone the Orchard source code onto your dev machine. It's the easiest way to keep up to date when new code is released. As a bonus, if you haven't got to grips with Git and GitHub, this will gently introduce you to the whole process.
 
 > If you need detailed help installing Git Extensions and cloning the repository this process is described in the [setting up a source enlistment](Setting-up-a-source-enlistment) tutorial in step-by-step detail.
 
@@ -18,7 +18,7 @@ You will probably have noticed that Orchard code has the braces on the same line
         }
     }
     
-Instead of what you normally see with .NET code where the opening curly brace is on it's own line, which looks like this:
+Instead of what you normally see with .NET code where the opening curly brace is on its own line, which looks like this:
 
     namespace Orchard.LearnOrchard.Example.Models
     {

--- a/docs/Documentation/Themes.markdown
+++ b/docs/Documentation/Themes.markdown
@@ -158,12 +158,12 @@ What we should focus on is that a single entity such as a theme is kept entirely
 
 The contents of a theme are images, stylesheets, pages, user controls and code. The files a theme can contain are:
 
-* Theme.txt: the manifest of the theme, where the meta-data for the theme is defined. If the manifest file is missing from a theme or if it can't be read, the admin UI will display the theme disabled (this is debatable) with a warning message explaining the problem: "This theme is missing a valid theme.txt manifest file."
-* Theme.png: the thumbnail that will appear in the theme galleries. This thumbnail should be relatively high resolution to enable JavaScript enhancements in the admin UI to show the higher resolution on hover. The high resolution thumbnail will be resized by the style of the img tag to a standard width when displayed in the list of themes.
-* Site.css: this is where most of the styles for the theme are defined. To enable settings to be inserted dynamically, a theme might have a dynamic style section in the master page or the template pages, in addition to the static link to the stylesheet.
-* Views/Templates/Default.aspx: this is the default layout template. It typically contains a main zone where the application will insert a partial view depending on the nature of the contents being displayed (list of posts or details of a post for the home page of a blog, details of a product, etc.).
-* Images: a directory containing the images used by the theme.
-* Scripts: a directory containing the client scripts used by the theme.
+* `Theme.txt`: the manifest of the theme, where the meta-data for the theme is defined. If the manifest file is missing from a theme or if it can't be read, the admin UI will display the theme disabled (this is debatable) with a warning message explaining the problem: "This theme is missing a valid Theme.txt manifest file."
+* `Theme.png`: the thumbnail that will appear in the theme galleries. This thumbnail should be relatively high resolution to enable JavaScript enhancements in the admin UI to show the higher resolution on hover. The high resolution thumbnail will be resized by the style of the img tag to a standard width when displayed in the list of themes.
+* `Site.css`: this is where most of the styles for the theme are defined. To enable settings to be inserted dynamically, a theme might have a dynamic style section in the master page or the template pages, in addition to the static link to the stylesheet.
+* `Views/Templates/Default.aspx`: this is the default layout template. It typically contains a main zone where the application will insert a partial view depending on the nature of the contents being displayed (list of posts or details of a post for the home page of a blog, details of a product, etc.).
+* `Images`: a directory containing the images used by the theme.
+* `Scripts`: a directory containing the client scripts used by the theme.
 
 Other, more specialized views and partial views may be optionally included into a theme, following a naming convention as described in the next section.
 
@@ -202,11 +202,11 @@ The plug-in has the following signature:
          string viewName, Theme theme, ControllerContext context)
 
 
-A view resolution plug-in should return null if it can't find a relevant view. If no plug-in exists or if all returned null, the framework will use default.aspx or default.ascx (depending on whether a full or partial view is necessary in the calling context). As soon as any enabled plug-in returns something other than null, empty string or "default", the framework stops the call loop and uses that value as the name of the physical view to use. This implies that the order in which plug-ins run may be important. This order can be determined from the plug-in admin UI.
+A view resolution plug-in should return null if it can't find a relevant view. If no plug-in exists or if all returned null, the framework will use `default.aspx` or `default.ascx` (depending on whether a full or partial view is necessary in the calling context). As soon as any enabled plug-in returns something other than null, empty string or "default", the framework stops the call loop and uses that value as the name of the physical view to use. This implies that the order in which plug-ins run may be important. This order can be determined from the plug-in admin UI.
 
 The view name that is getting passed into the plug-in is typically just what the controller action asked for. The plug-in system allows for arbitrary flexibility in selecting a physical view from what the action is asking for, depending on any convention and keeping the end result within what the current theme is able to display.
 
-The default view selection plug-in will try to find a view with \[viewName\]\.aspx as the name within the theme and return this if it is found. If not, it will assume that the view name is built using the following convention: `viewName = [ContentType]-[ItemSlug]`
+The default view selection plug-in will try to find a view with `<viewName>.aspx` as the name within the theme and return this if it is found. If not, it will assume that the view name is built using the following convention: `viewName = [ContentType]-[ItemSlug]`
 
 The default view resolver will split the file name on the first dash character, will remove what comes after and try to find a physical view with that name.
 
@@ -245,9 +245,9 @@ Here's a possible implementation of the default view resolution plug-in:
 
 Of course, implementing any other convention to resolve the controller action-provided view name to a physical view name is just a matter of implementing a plug-in.
  
-In the example of displaying a blog post, one can see that the controller would ask for a view named for example "post-my-first-post". The default view resolver would ask the current theme for a view named "post-my-first-post". If it doesn't find it (which is quite likely), it will look for a view named "post". If the current theme has been built for the blog application, it will most likely have it and that's what will be used, otherwise the engine will ask other plug-ins and ultimately fall back to "default".
+In the example of displaying a blog post, one can see that the controller would ask for a view named for example `post-my-first-post`. The default view resolver would ask the current theme for a view named `post-my-first-post`. If it doesn't find it (which is quite likely), it will look for a view named `post`. If the current theme has been built for the blog application, it will most likely have it and that's what will be used, otherwise the engine will ask other plug-ins and ultimately fall back to `default`.
 
-In the example of a commerce package, the controller could ask for "category-boots". The theme could contain that view but if it doesn't the default implementation will try to find "category" and then revert to default.
+In the example of a commerce package, the controller could ask for `category-boots`. The theme could contain that view but if it doesn't the default implementation will try to find `category` and then revert to default.
 
 But we can also look at other patterns to resolve views.
 For example, here's the code for a plug-in that implements the page branch of a resolution tree:
@@ -333,11 +333,11 @@ The description for each setting can have a description and an editor hint. This
 
 There is no type information associated with a setting because the intended audience for theme authoring shouldn't be required to understand such coding concepts. Instead, seen from the theme views, all theme settings are strings and can be injected easily.
 
-It's the editor that is responsible for translating the value of a setting back and forth between the string representation and any internal representation it may need in order to provide a good editing experience. For example, a color setting would be represented in a "#RRGGBB" format that is immediately usable in HTML, but the editor would transform that representation into an instance of the Color type internally, and would surface color picker UI in the admin view to edit it. When it's done, it would persist the string representation back to the theme engine.
+It's the editor that is responsible for translating the value of a setting back and forth between the string representation and any internal representation it may need in order to provide a good editing experience. For example, a color setting would be represented in a `#RRGGBB` format that is immediately usable in HTML, but the editor would transform that representation into an instance of the Color type internally, and would surface color picker UI in the admin view to edit it. When it's done, it would persist the string representation back to the theme engine.
 
 The editor is also responsible for validation of setting values.
 
-Theme settings can be injected into a view using the Html.Theme helper (see [Theme Includes and Overrides](themes-includes)).
+Theme settings can be injected into a view using the `Html.Theme` helper (see [Theme Includes and Overrides](themes-includes)).
 
 There is a set of setting values per theme so that switching to a new theme switches to a new set of values, and going back to the original theme restores the corresponding values.
 
@@ -353,7 +353,7 @@ The stylesheet overrides will be served by a special action. The views will incl
 
 #### The themes directory
 
-Each theme is found as a subdirectory under the "themes" subdirectory of the root of the application. The name of the theme's directory should be the same as the name of the class in theme.cs if there is one.
+Each theme is found as a subdirectory under the `Themes` subdirectory of the root of the application. The name of the theme's directory should be the same as the name of the class in `theme.cs` if there is one.
 
 #### Stylesheet overrides
 

--- a/docs/Documentation/Understanding-data-access.markdown
+++ b/docs/Documentation/Understanding-data-access.markdown
@@ -21,7 +21,7 @@ A record is a class that represents the database schema for a content part. To c
     }
 
 
-Typically, the record class resides in a folder named Models. The parent class, `ContentPartRecord`, also includes a property named `id` and a reference to the content item object. Therefore, an instance of the `MapRecord` class includes not just `Latitude` and `Longitude` but also the `id` property and the content item object that is used to maintain the relationships between the part and other content.
+Typically, the record class resides in a folder named `Models`. The parent class, `ContentPartRecord`, also includes a property named `id` and a reference to the content item object. Therefore, an instance of the `MapRecord` class includes not just `Latitude` and `Longitude` but also the `id` property and the content item object that is used to maintain the relationships between the part and other content.
 
 When you define a content part, you use the record as shown below:
 
@@ -48,7 +48,7 @@ When you define a content part, you use the record as shown below:
 
 Notice that only data that's relevant to the part is defined in the `MapPart` class. You do not define any properties that are needed to maintain the data relationships between `MapPart` and other content.
 
-For a complete example of the MapPart, see [Writing a Content Part](Writing-a-content-part). You can also read the [Getting Started with Modules course](Getting-Started-with-Modules) to familiarize yourself with the overall concepts of module development.
+For a complete example of the `MapPart`, see [Writing a Content Part](Writing-a-content-part). You can also read the [Getting Started with Modules course](Getting-Started-with-Modules) to familiarize yourself with the overall concepts of module development.
 
 ## Data Migrations
 Creating the record class does not create the database table; it only creates a model of the schema. To create the database table, you must write a data migration class.
@@ -61,7 +61,7 @@ You can create a data migration class by running the following command from the 
     codegen datamigration <feature_name>
 
 
-This command creates a _Migrations.cs_ file in the root of the feature. A `Create` method is automatically created in the migration class.
+This command creates a `Migrations.cs` file in the root of the feature. A `Create` method is automatically created in the migration class.
 
 In the `Create` method, you use the `SchemaBuilder` class to create the database table, as shown below for the `MapPart` feature.
 
@@ -149,6 +149,6 @@ A content handler is similar to a filter in ASP.NET MVC. In the handler, you def
 In more advanced content handlers, you define actions that are performed when an event occurs, such as when the feature is published or activated. For more information about content handlers, see [Understanding Content Handlers](Understanding-content-handlers).
 
 ## Content Drivers
-A content driver is similar to a controller in ASP.NET MVC. It contains code that is specific to a content part type and is usually involved in creating data shapes for different conditions, such as display or edit modes. Typically, you override the **Display** and **Editor** methods to return the **ContentShapeResult** object for your scenario.
+A content driver is similar to a controller in ASP.NET MVC. It contains code that is specific to a content part type and is usually involved in creating data shapes for different conditions, such as display or edit modes. Typically, you override the `Display` and `Editor` methods to return the `ContentShapeResult` object for your scenario.
 
 For an example of using a content driver, see [Accessing and Rendering Shapes](Accessing-and-rendering-shapes).

--- a/docs/Documentation/Understanding-placement-info.markdown
+++ b/docs/Documentation/Understanding-placement-info.markdown
@@ -5,7 +5,7 @@ To get a template to render an object like this, you could access each of these 
 In Orchard, this isn't necessary, and adding a new part and displaying it can be done without touching the templates. This is possible because Orchard separates layout into two stages:
 
   - Rendering (performed by generating HTML from templates or shape methods) and
-  - Placement (done through the `placement.info` file).
+  - Placement (done through the `Placement.info` file).
 
 This way, parts can not only specify their default rendering, which can be overridden by themes, they can also specify where they prefer to be rendered relative to other parts (which can also be overridden by themes).
 
@@ -13,7 +13,7 @@ This way, parts can not only specify their default rendering, which can be overr
 > 
 > Instead, create templates for Content Parts and Content Fields then change their order with placement.
 
-Specifying placement using the `placement.info` file is the subject of this article.
+Specifying placement using the `Placement.info` file is the subject of this article.
 
 ## Summary
 
@@ -42,11 +42,11 @@ Specifying placement using the `placement.info` file is the subject of this arti
 <tr><th>Shape<td colspan="2">;Shape=new_shape_name
 </table>
 
-## The placement.info File
+## The `Placement.info` File
 
-If you look at the files in your Orchard website, you'll see that most modules and themes have a `placement.info` file at their root. This is an XML file that specifies the placement of each part of a content item.
+If you look at the files in your Orchard website, you'll see that most modules and themes have a `Placement.info` file at their root. This is an XML file that specifies the placement of each part of a content item.
 
-The following example shows an example of a placement file. (It's based on the `placement.info` file that comes with `Orchard.Tags`.)
+The following example shows an example of a placement file. (It's based on the `Placement.info` file that comes with `Orchard.Tags`.)
 
     <Placement>
         <Place Parts_Tags_Edit="Content:7"/>
@@ -67,15 +67,15 @@ The following example shows an example of a placement file. (It's based on the `
 A placement file acts at the Content Item level. This means that you can use it to reorder the display of the parts of anything that is a content item (blog posts, pages, comments, custom items, widgets, elements, etc.), but not necessarily arbitrary shapes. If a shape that is not representing a content part needs placement, it is up to you to provide a placement mechanism for that shape.
 
 ## Comments
-Comments can be included in the `placement.info` using normal `<!-- comment -->` syntax.
+Comments can be included in the `Placement.info` using normal `<!-- comment -->` syntax.
 
 ## The "Placement" Element
 
-The `Placement` element must be present at the root of the `placement.info` document. It is a simple container.
+The `Placement` element must be present at the root of the `Placement.info` document. It is a simple container.
 
 ## "Place" Element
 
-The `Place` element is the main entity in a `placement.info` file. It can have any number of attributes, although it's recommended for readability to have only one shape place defined per `Place` element. For additional shapes, you can add more `Place` tags, one per line.
+The `Place` element is the main entity in a `Placement.info` file. It can have any number of attributes, although it's recommended for readability to have only one shape place defined per `Place` element. For additional shapes, you can add more `Place` tags, one per line.
 
 Single shape per line example:
 
@@ -175,7 +175,7 @@ Similarly, you can provide a wrapper as part of the placement (`Header:after;Wra
 
 Using a wrapper enables wrapping content with a cshtml markup. Here is a 3 step example showing how to add a div around the Html Widget to enable css styling of the widget.
 
-In placement.info : 
+In `Placement.info` : 
 
     <Match ContentType="Widget">
         <Place Parts_Common_Body="Content:5;Wrapper=Wrapper_HtmlContent" />
@@ -183,7 +183,7 @@ In placement.info :
 
 If you just put the wrapper without specifying 'Content:5' the body part will not show up. By adding `Content:5` it specifies which zone to render the part in.
 
-After modifying your placement.info the Shape Tracing module Shape tab will show your wrapper location at the bottom. It will be: `~/Themes/{yourTheme}/Views/Wrapper.HtmlContent.cshtml`. 
+After modifying your `Placement.info` the Shape Tracing module Shape tab will show your wrapper location at the bottom. It will be: `~/Themes/{yourTheme}/Views/Wrapper.HtmlContent.cshtml`. 
 
 Create this file and put the following text in it:
 
@@ -243,7 +243,7 @@ _The `ContentPart` attribute was added in v1.7.2_
 
 Scopes the contained `Place` tags to a specific content part such as `BodyPart` or `LayoutPart`. An example use of this scoping is to hide the title part in a content item with a `LayoutPart`.
 
-In placement.info :
+In `Placement.info` :
 
     <Match ContentPart="LayoutPart">
         <Place Parts_Title="-" />
@@ -264,10 +264,10 @@ Scopes the contained `Place` tags to a specific path or to a path and its childr
 
 ## Overriding Placement
 
-A module should define default placements for the parts and fields it provides by having a `placement.info` file at the root of the module's directory.
+A module should define default placements for the parts and fields it provides by having a `Placement.info` file at the root of the module's directory.
 
 Without a placement your parts and fields will not appear on the page. By supplying a default you take the burden away from theme developers to configure your module and you make it easy for them to copy sections over to customise them. Consider the various DisplayTypes your parts and fields may be viewed and provide sensible defaults.  
 
-That default placement can be overridden by any theme by placing a `placement.info` file in the root of the theme directory.
+That default placement can be overridden by any theme by placing a `Placement.info` file in the root of the theme directory.
 
 The current theme's placement will win over that of any module.

--- a/docs/Documentation/Working-with-Orchard-in-WebMatrix.markdown
+++ b/docs/Documentation/Working-with-Orchard-in-WebMatrix.markdown
@@ -57,12 +57,12 @@ Although WebMatrix does not provide a build system for compiling code files, Orc
 
 You can change the editor WebMatrix uses by following these [instructions](http://sybak.com/blog/2011/02/changing-the-file-types-that-open-with-webmatrix/). 
  
-As an example, you may find it helpful to use the XML editor (which provides colorization) on the placement.info file.  To do this you must change the setting for *.info* files in the WebMatrix file **filetypes.xml** (which can be found in the following locations):
+As an example, you may find it helpful to use the XML editor (which provides colorization) on the `Placement.info` file.  To do this you must change the setting for `.info` files in the WebMatrix file `filetypes.xml` (which can be found in the following locations):
 
     32-bit machines: C:\Program Files\Microsoft WebMatrix\config\filetypes.xml
     64-bit machines: C:\Program Files (x86)\Microsoft WebMatrix\config\filetypes.xml
 
-1) Add the .info file extension to the list of XML file types:
+1) Add the `.info` file extension to the list of XML file types:
 
 
     <FileType extension=".info;.config;.csproj;.vbproj;.resx;.settings;.sitemap;.user;.wsdl;.browser;.xaml;.xml;.xoml;.xsd;.xsl;.xslt;.mxml;.dbml;.wstemplate">
@@ -73,7 +73,7 @@ As an example, you may find it helpful to use the XML editor (which provides col
         <Description>An XML File</Description>
     </FileType>
 
-2) Remove the .info file extension from the list of Text file types:
+2) Remove the `.info` file extension from the list of Text file types:
 
     <FileType extension=".ashx;.export;.po;.blogtemplate;.yml;.yaml;.manifest;.pl;.json;.csv">
         <OpenAs>Text</OpenAs>

--- a/docs/Documentation/Writing-a-content-part.markdown
+++ b/docs/Documentation/Writing-a-content-part.markdown
@@ -1,18 +1,18 @@
 > **This guide has been marked for review.** If you are just getting started with Orchard module development you should read the [Getting Started with Modules course](Getting-Started-with-Modules) first. It will introduce you to building modules with Orchard using Visual Studio Community, a free edition of Visual Studio. 
 
 
-This tutorial walks through the process of creating a new content part from scratch, using the scaffolding feature in Orchard as a productivity tool.  Although this tutorial assumes development in Visual Studio, it is not strictly necessary to have Visual Studio to develop a content part - feel free to use your editor of choice.  
+This tutorial walks through the process of creating a new content part from scratch, using the scaffolding feature in Orchard as a productivity tool.  Although this tutorial assumes development in Visual Studio, it is not strictly necessary to have Visual Studio to develop a content part -- feel free to use your editor of choice.  
 
-In this tutorial, we are going to build a custom Map part, that can be configured with latitude and longitude values in order to display a map image for a content item.
+In this tutorial, we are going to build a custom `Map` part that can be configured with latitude and longitude values in order to display a map image for a content item.
 
 
 > **Important:** Before you can generate the file structure for your module, you need to download, install, and enable the **Code Generation** feature for Orchard. For more information, see [Command-line Code Generation](Command-line-scaffolding).
 
-We are going to add a new "Maps" module to contain our Map part implementation, as a new project in the Orchard solution.  Assuming you have enlisted in the Orchard source tree, launch Visual Studio 2010 and open the Orchard.sln file under the "src" folder of your enlistment.
+We are going to add a new `Maps` module to contain our `Map` part implementation, as a new project in the Orchard solution.  Assuming you have enlisted in the Orchard source tree, launch Visual Studio 2010 and open the `Orchard.sln` file under the `src` folder of your enlistment.
 
 ![](../Upload/screenshots/vs_soln_explorer.png)
 
-Type "codegen module Maps /IncludeInSolution:true" at the Orchard command-prompt.  The "IncludeInSolution" switch tells Orchard to wire up a new Maps module project to the Orchard.sln file.
+Type `codegen module Maps /IncludeInSolution:true` at the Orchard command-prompt.  The `IncludeInSolution` switch tells Orchard to wire up a new `Maps` module project to the `Orchard.sln` file.
 
     
     orchard> codegen module Maps /IncludeInSolution:true
@@ -24,11 +24,11 @@ After running this command, Visual Studio prompts to re-load the solution file. 
 
 ![](../Upload/screenshots_85/vs_soln_reload.png)
 
-The Maps module project appears added to the solution, along with some default files and folder to get you started.
+The `Maps` module project appears added to the solution, along with some default files and folder to get you started.
 
 ![](../Upload/screenshots/vs_soln_maps_module.png)
 
-Open the Module.txt file at the root of the Maps module project.  This file defines the information about your module, such as a name, description, version, author, and a categorized of features exposed by the module.  The Module.txt file can also contain additional information such as dependencies, which we will not cover here.  Our module is pretty simple, and only contains a single "Maps" feature with no additional dependencies.  Edit the Module.txt file as indicated below.
+Open the `Module.txt` file at the root of the `Maps` module project.  This file defines the information about your module, such as a name, description, version, author, and a categorized of features exposed by the module.  The `Module.txt` file can also contain additional information such as dependencies, which we will not cover here.  Our module is pretty simple, and only contains a single `Maps` feature with no additional dependencies.  Edit the `Module.txt` file as indicated below.
 
     
     Name: Maps
@@ -44,11 +44,11 @@ Open the Module.txt file at the root of the Maps module project.  This file defi
             Category: Geolocation
 
 
-Now let's begin to write the Map part.  To begin with, we need a class to contain the data for the part. Data classes are conventionally added to the "Models" folder of the project.  Right-click the Models folder in Visual Studio and choose "Add > Class" from the context menu and name the new file Map.cs:
+Now let's begin to write the `Map` part.  To begin with, we need a class to contain the data for the part. Data classes are conventionally added to the `Models` folder of the project.  Right-click the `Models` folder in Visual Studio and choose **Add > Class** from the context menu and name the new file `Map.cs`:
 
 ![](../Upload/screenshots_675/vs_add_model_class.png)
 
-In Orchard, content part data is represented by a Record class, which represents the fields that are stored to a database table, and a ContentPart class that uses the Record for storage.  Add the MapRecord (ContentPartRecord) and MapPart (ContentPart) classes as follows:
+In Orchard, content part data is represented by a `Record` class, which represents the fields that are stored to a database table, and a `ContentPart` class that uses the `Record` for storage.  Add the `MapRecord` (`ContentPartRecord`) and `MapPart` (`ContentPart`) classes as follows:
 
     
     using System.ComponentModel.DataAnnotations;
@@ -82,13 +82,13 @@ In Orchard, content part data is represented by a Record class, which represents
     }
 
 
-Now build the Maps project to ensure your Record class compiles successfully.
+Now build the `Maps` project to ensure your `Record` class compiles successfully.
 
 ![](../Upload/screenshots/vs_build_maps.png)
 
-Next, we are going to create a data migration for our Maps module.  Why do we need a migration class?  The reason is that defining a Record and Part class to store the data doesn't actually impact the database in any way.  A data migration is what tells Orchard how to update the database schema when the Maps feature is enabled (the migration runs when the feature is activated).  A migration can also upgrade the database schema from prior versions of a module to the schema required by a newer version of a module - this is an advanced topic that won't be covered in this tutorial.
+Next, we are going to create a data migration for our `Maps` module.  Why do we need a migration class?  The reason is that defining a `Record` and `Part` class to store the data doesn't actually impact the database in any way.  A data migration is what tells Orchard how to update the database schema when the `Maps` feature is enabled (the migration runs when the feature is activated).  A migration can also upgrade the database schema from prior versions of a module to the schema required by a newer version of a module - this is an advanced topic that won't be covered in this tutorial.
 
-To create a new data migration class, you can use the Code Generation feature of Orchard.  Run "codegen datamigration Maps" from the Orchard command-line.
+To create a new data migration class, you can use the Code Generation feature of Orchard.  Run `codegen datamigration Maps` from the Orchard command-line.
 
     
     orchard> codegen datamigration Maps
@@ -100,7 +100,7 @@ Visual Studio prompts to re-load the solution again.  After accepting this promp
 
 ![](../Attachments/Writing-a-content-part/vs_sol_migration.PNG)
 
-The migration class added by the codegen command contains a single Create() method that defines a database table structure based on the Record classes in project.  Because we only have a single MapRecord class with latitude and longitude properties, the migration class is fairly simple.  Note that the Create method is called at the time the feature is activated, and the database will be updated accordingly.
+The migration class added by the `codegen` command contains a single `Create()` method that defines a database table structure based on the `Record` classes in the project.  Because we only have a single `MapRecord` class with latitude and longitude properties, the migration class is fairly simple.  Note that the `Create` method is called at the time the feature is activated, and the database will be updated accordingly.
 
     
     using System;
@@ -133,9 +133,9 @@ The migration class added by the codegen command contains a single Create() meth
     }
 
 
-Add the AlterPartDefinition lines to the migration in order to make the part attachable to any content type. Also add `using Maps.Models;` to the top of the file.
+Add the `AlterPartDefinition` lines to the migration in order to make the part attachable to any content type. Also add `using Maps.Models;` to the top of the file.
 
-Now let's add the handler for the Map part.  A handler in Orchard is a class that defines the behavior of the part, handling events or manipulating data model prior to rendering the part.  The Map part is very simple, and in this case, our handler class will only specify that an IRepository of MapRecord should be used as the storage for this part. Add the following Handlers\MapHandler.cs:
+Now let's add the handler for the `Map` part.  A handler in Orchard is a class that defines the behavior of the part, handling events or manipulating data model prior to rendering the part.  The `Map` part is very simple, and in this case, our handler class will only specify that an `IRepository` of `MapRecord` should be used as the storage for this part. Add the following `Handlers\MapHandler.cs` file:
 
     
     using Maps.Models;
@@ -151,7 +151,7 @@ Now let's add the handler for the Map part.  A handler in Orchard is a class tha
     }
 
 
-We will also add a driver for our Map part.  A driver in Orchard is a class that can define associations of shapes to display for each context in which the Map part can render.  For example, when displaying a Map on the front-end, a "Display" method defines the name of the template to use for different displayTypes (for example, "details" or summary").  Similarly, an "Editor" method of the driver defines the template to use for displaying the editor of the Map part (for entering values of the latitude and longitude fields).  We are going to keep this part simple and just use "Map" as the name of the shape to use for both Display and Editor contexts (and all displayTypes).  Add the Drivers\MapDriver class as follows.
+We will also add a driver for our `Map` part.  A driver in Orchard is a class that can define associations of shapes to display for each context in which the `Map` part can render.  For example, when displaying a `Map` on the front-end, a `Display` method defines the name of the template to use for different displayTypes (for example, "details" or "summary").  Similarly, an `Editor` method of the driver defines the template to use for displaying the editor of the `Map` part (for entering values of the latitude and longitude fields).  We are going to keep this part simple and just use `Map` as the name of the shape to use for both `Display` and `Editor` contexts (and all displayTypes).  Add the `Drivers\MapDriver` class as follows.
 
     
     using Maps.Models;
@@ -189,9 +189,9 @@ We will also add a driver for our Map part.  A driver in Orchard is a class that
     }
 
 
-We can now add the display and editor views in Visual Studio. First add "Parts" and "EditorTemplates/Parts" folders to the "Views" folder in the Maps project, and then add Map.cshtml files into the Views/EditorTemplates/Parts and the Views/Parts folders as follows.
+We can now add the display and editor views in Visual Studio. First add `Parts` and `EditorTemplates/Parts` folders to the `Views` folder in the `Maps` project, and then add `Map.cshtml` files into the `Views/EditorTemplates/Parts` and the `Views/Parts` folders as follows.
 
-Views/EditorTemplates/Parts/Map.cshtml :
+`Views/EditorTemplates/Parts/Map.cshtml`:
     
     @model Maps.Models.MapPart
     
@@ -216,7 +216,7 @@ Views/EditorTemplates/Parts/Map.cshtml :
                 
     </fieldset>
 
-Views/Parts/Map.cshtml :
+`Views/Parts/Map.cshtml`:
     
     <img alt="Location" border="1" src="http://maps.google.com/maps/api/staticmap? 
          &zoom=14
@@ -226,7 +226,7 @@ Views/Parts/Map.cshtml :
          &sensor=false" />
 
 
-Both of these templates will be rendered as parts of a larger, composite page. Because the system needs to know the order and location where they will render within the composed page, we need to add a Placement.info file into the root of the module's directory:
+Both of these templates will be rendered as parts of a larger, composite page. Because the system needs to know the order and location where they will render within the composed page, we need to add a `Placement.info` file into the root of the module's directory:
 
     
     <Placement>
@@ -235,34 +235,34 @@ Both of these templates will be rendered as parts of a larger, composite page. B
     </Placement>
 
 
-This is saying that the Parts_Map shape (which is rendered by Views/Parts/Map.cshtml unless overridden in the current theme) should render in the "Content" zone if available, in tenth position. It also positions the editor shape/template in the "Primary" zone in second position.
+This is saying that the `Parts_Map` shape (which is rendered by `Views/Parts/Map.cshtml` unless overridden in the current theme) should render in the "Content" zone if available, in tenth position. It also positions the editor shape/template in the "Primary" zone in second position.
 
-To activate the Map part, go to the "Features" section of the Orchard admin panel and enable it.
+To activate the Map part, go to the **Features** section of the Orchard admin panel and enable it.
 
 ![](../Upload/screenshots/enable_maps.png)
 
-You can try out the Map part by attaching it to any content type in the system, using the "Content Types" section of the Orchard admin panel.  Let's add it to an existing content type, namely, the custom "Event" content type that we built in the [Creating custom content types](Creating-custom-content-types) topic.  If you haven't read that topic yet or don't have the "Event" type, go ahead and add the Map to the Page content type instead (following the same steps below).
+You can try out the `Map` part by attaching it to any content type in the system, using the **Content Types** section of the Orchard admin panel.  Let's add it to an existing content type, namely, the custom `Event` content type that we built in the [Creating custom content types](Creating-custom-content-types) topic.  If you haven't read that topic yet or don't have the `Event` type, go ahead and add the `Map` to the `Page` content type instead (following the same steps below).
 
-On the "Manage Content Types" admin screen, click on "Edit" to edit the definition of this type (you may need to enable the Orchard.ContentTypes feature first).
+On the **Manage Content Types** admin screen, click on **Edit** to edit the definition of this type (you may need to enable the `Orchard.ContentTypes` feature first).
 
 ![](../Upload/screenshots_675/edit_content_type_event.png)
 
-In the list of parts for the "Event" type, click on "Add" to add a part.
+In the list of parts for the `Event` type, click on **Add** to add a part.
 
 ![](../Upload/screenshots_675/add_parts_event.png)
 
-The Map part displays in the list of available parts to add.  Select it, and click "Save".
+The `Map` part displays in the list of available parts to add.  Select it, and click **Save**.
 
 ![](../Upload/screenshots_85/add_parts_event_map.png)
 
-Now go the "Manage Content" and edit an event content item.  Notice that the Map part adds Latitude and Longitude fields to this item.  Type some valid coordinates and re-publish the content item.
+Now go the **Manage Content** and edit an event content item.  Notice that the `Map` part adds `Latitude` and `Longitude` fields to this item.  Type some valid coordinates and re-publish the content item.
 
 ![](../Upload/screenshots_675/edit_event_map_fields.png)
 
-On the front-end of your site, you can see the effect of the Map part rendering on the event content item.
+On the front-end of your site, you can see the effect of the `Map` part rendering on the event content item.
 
 ![](../Upload/screenshots_675/view_event_map.png)
 
 # Getting the Code
 
-The Map part described in this topic is available from here: [Orchard.Module.Maps.1.0.0.zip](../Attachments/Writing-a-content-part/Orchard.Module.Maps.1.0.0.zip), ready to install and use, with full source code.
+The `Map` part described in this topic is available from here: [Orchard.Module.Maps.1.0.0.zip](../Attachments/Writing-a-content-part/Orchard.Module.Maps.1.0.0.zip), ready to install and use, with full source code.


### PR DESCRIPTION
- Markup literals using `backticks`.
- Avoid a lot of backslash-escaping, just use `literal` markup for literals.
- Markup UI elements as **bold**.
- Consistently capitalise filenames the way they're actually present in the code.
  Placement.txt, Module.txt, Theme.txt.
- Use Markdown shorthand for em-dash: `--`.
- Use _emphasis_ to distinguish concepts.
- Opportunistically update examples from current source code.
- Grammar and typo fixes.
- Fix "it's" (means: "it is") vs. "its" (possessive).