### PR TITLE
syntax overview needs case sensitive example

### DIFF
--- a/docs/Documentation/Understanding-placement-info.markdown
+++ b/docs/Documentation/Understanding-placement-info.markdown
@@ -26,11 +26,11 @@ Specifying placement using the `Placement.info` file is the subject of this arti
 
 ## Syntax Overview
 
-    <placement>
-        [ <match scope> ]
-            <place Shape_Name="order[;alternate][;wrapper][;shape]" />
-        [ </match> ]
-    </placement>
+    <Placement>
+        [ <Match scope> ]
+            <Place Shape_Name="order[;alternate][;wrapper][;shape]" />
+        [ </Match> ]
+    </Placement>
 
 <table>
 <tr><th>Scope<td colspan="2">ContentType="value" | ContentPart="value" | DisplayType="value" | Path="value"


### PR DESCRIPTION
elements in placement xml needs to use capital letters for elements like Placement, Match, Place. The only place this was incorrect was in the syntax overview