### PR TITLE
Update to conditions/rules documentation

### DIFF
--- a/docs/Documentation/Using-Rules-to-conditionally-display-content.markdown
+++ b/docs/Documentation/Using-Rules-to-conditionally-display-content.markdown
@@ -1,3 +1,5 @@
+> This topic targets, and was tested with, the Orchard 1.10.2 release.
+
 In Orchard, you can use rules to determine the visibility of both layers (see [Managing widgets](Managing-widgets)) and elements within a Layout.
 
 A rule is composed of one or more conditions which are combined using one or more logical operators such as AND, OR and NOT. This article describes how to compose a rule using conditions and lists the conditions that are available within a standard Orchard installation.

--- a/docs/Documentation/Using-Rules-to-conditionally-display-content.markdown
+++ b/docs/Documentation/Using-Rules-to-conditionally-display-content.markdown
@@ -44,7 +44,7 @@ not                                    | n/a                  | Logical NOT.
 and                                    | n/a                  | Logical AND.
 or                                     | n/a                  | Logical OR.
 
-The presence of `[]` in the condition syntax denotes the fact tha this condition accepts multiple parameters. Examples of using these conditions with multiple parameters are given below.
+The presence of `[]` in the condition syntax denotes the fact that this condition accepts multiple parameters. Examples of using these conditions with multiple parameters are given below.
 
 You can find modules that implement additional conditions by [searching the gallery for the term 'rules'](http://gallery.orchardproject.net/Packages/Modules?q=rules).
 

--- a/docs/Documentation/Using-Rules-to-conditionally-display-content.markdown
+++ b/docs/Documentation/Using-Rules-to-conditionally-display-content.markdown
@@ -1,31 +1,34 @@
-In Orchard, you can use rules to determine the visibility of both layers (see [Managing widgets](Managing-widgets) and elements within a Layout.
+In Orchard, you can use rules to determine the visibility of both layers (see [Managing widgets](Managing-widgets)) and elements within a Layout.
 
-This article describes the rules that are available in a standard Orchard installation and how you can use them.
+A rule is composed of one or more conditions which are combined using one or more logical operators such as AND, OR and NOT. This article describes how to compose a rule using conditions and lists the conditions that are available within a standard Orchard installation.
 
 # Rules
-Rules are implemented by the Orchard.Conditions core module, which provides a couple of standard rules that you can use:
+A rule is constructed by using one, or more, *conditions* that are checked to determine whether the rule overall evaluates to *true* or *false*. If the rule evaluates to *true*, the associated content will be displayed, if not, then it won't.
 
-- "authenticated" - Whether the current user is authenticated, or not
-- "url" - To allow you to check whether the current request matches a certain URL, or not
+There are two basic conditions provided by the Orchard.Conditions module, these are:
 
-These allow you to compose expressions that determine whether a given layer or element is visible, for example:
+- `authenticated` - Whether the current user is authenticated, or not
+- `url` - To allow you to check whether the current request matches a certain URL, or not
+
+These allow you to compose rules that determine whether a given layer or element is visible, for example:
 
     (not authenticated and url("~/about")) or authenticated
 
-If this expression was applied to a certain layer, the contents of the layer would be visible if:
+If this rule was applied to a certain layer, the contents of the layer would be visible if:
 
 - the user is not logged in *AND* the page is the "about" page, **or**
 - the user is logged in
 
-There are also other rules, implemented by other Orchard modules, that are described in detail below.
+There are also other conditions that you can use to compose rules, implemented by other Orchard modules, that are described in detail below.
 
-## Available Rules
-There are several rules provided by the core Orchard modules, over and above the `authenticated` and `url` ones provided by the Orchard.Conditions module itself. In order to use a rule, the module it's provided by must be both installed and enabled, otherwise you may receive the below error message when attempting to use the rule:
+## Available Conditions
+There are several conditions provided by the core Orchard modules, over and above the `authenticated` and `url` ones provided by the Orchard.Conditions module itself. In order to use a condition, the module it's provided by must be both installed and enabled, otherwise you may receive the below error message when attempting to use the condition:
 
 > The rule is not valid: Expression is not a boolean value
-The rules provided are:
 
-Rule Syntax                            | Module               | Description
+The conditions provided are:
+
+Condition Syntax                       | Module               | Description
 ---------------------------------------| ---------------------|-----------------------
 authenticated                          | Orchard.Conditions   | True if the user is logged in.
 ContentType("&lt;Type&gt;")            | Orchard.Widgets      | True if the content type being view matches the content type specified e.g. `ContentType("Page")`
@@ -39,13 +42,13 @@ not                                    | n/a                  | Logical NOT.
 and                                    | n/a                  | Logical AND.
 or                                     | n/a                  | Logical OR.
 
-The presence of `[]` in the rule syntax denotes the fact tha this rule accepts multiple parameters. Examples of using these rules with multiple parameters are given below.
+The presence of `[]` in the condition syntax denotes the fact tha this condition accepts multiple parameters. Examples of using these conditions with multiple parameters are given below.
 
-You can find modules that implement additional rules by [searching the gallery for the term 'rules'](http://gallery.orchardproject.net/Packages/Modules?q=rules).
+You can find modules that implement additional conditions by [searching the gallery for the term 'rules'](http://gallery.orchardproject.net/Packages/Modules?q=rules).
 
-### Rules that take multiple parameters
+### Conditions that take multiple parameters
 
-Several of the rules provided within core Orchard modules allow you to specify more than one parameter, both examples for each of the following rules are equally valid:
+Several of the conditions provided within core Orchard modules allow you to specify more than one parameter. Both examples for each of the following rules (where the condition is used with a logical `or` and where the condition has an array of parameters passed to it) are equally valid:
 
 A rule to display content for either the en-gb or en-us culture code:
 
@@ -56,15 +59,20 @@ A rule to display content for either the English, or French language:
     
     culturelang("en") or culturelang("fr")
     culturelang("en", "fr")
-    
+
+A rule to display content for either of the 1033 and 2057 (en-us and en-gb) locales:
+
     culturelcid(1033) or culturelcid(2057)
     culturelcid(1033, 2057)
+
+A rule to display content for users who are members of the Moderator or Administrator roles:
 
     roles("Moderator") or roles("Administrator")
     roles("Moderator", "Administrator")
 
 ## Places you can use rules
 You can use rules to determine the visibility of things in at least these places:
+
 - Layers - to determine when a layer is visible
 - Layouts - to determine when individual elements within the layout are visible
 - Pages - to determine when individual elements within the page are visible (this is effectively the same as for a Layout as from Orchard v.1.9 onwards, by default the Page content type has a LayoutPart instead of the BodyPart)


### PR DESCRIPTION
Along with the previous commit from me (which should have referenced #295, but didn't, because I'm an idiot) this fixes #295 by:

- Documenting the conditions provided by Orchard.Conditions
- Documenting the conditions provided by other Orchard built-in modules
- Disambiguating the terms "condition" and "rule" to make it clear that a rule is composed from one, or more, conditions (see @DanielStolt in OrchardCMS/OrchardDoc#338)
- Adds the "targets and tested with" header that's referenced in Contributing-documentation.markdown
- Fixes up a layout issue I introduced in the "Places you can use rules" section

I'm going to spawn a separate issue for resolving the dissonance between Contributing.md in the root of the repository and the documentation that gets published to docs.orchardproject.net